### PR TITLE
Action: Fix uploading releases. Update versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ on:
 
 env:
   TRUNK_VERSION: 0.16.0
-  RUST_TOOLCHAIN: 1.69.0
+  RUST_TOOLCHAIN: 1.71.1
+  DART_SDK_VERSION: 3.0.7
+  DART_SASS_VERSION: 1.62.1
 
 jobs:
   test:
@@ -106,6 +108,19 @@ jobs:
 
       - name: Build tanoshi-web
         run: |
+          export DART_ARCH="linux-x64" && \
+          curl -s "https://storage.googleapis.com/dart-archive/channels/stable/release/${{ env.DART_SDK_VERSION }}/sdk/dartsdk-${DART_ARCH}-release.zip" -o "dartsdk-${DART_ARCH}-release.zip" && \
+          unzip "dartsdk-${DART_ARCH}-release.zip"
+
+          export PATH="$PATH:$(pwd)/dart-sdk/bin"
+
+          curl -sL "https://github.com/sass/dart-sass/archive/refs/tags/${{ env.DART_SASS_VERSION }}.zip" -o "${{ env.DART_SASS_VERSION }}.zip" && \
+          unzip "${{ env.DART_SASS_VERSION }}.zip" && \
+          cd "dart-sass-${{ env.DART_SASS_VERSION }}" && \
+          dart pub get && \
+          dart compile exe bin/sass.dart -o ${{ github.workspace }}/dart-sdk/bin/sass -Dversion="${{ env.DART_SASS_VERSION }}"
+
+          cd ${{ github.workspace }}
           cargo install trunk --version ${{ env.TRUNK_VERSION }} --locked
           cd crates/tanoshi-web && trunk build --release
 
@@ -126,6 +141,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+
     steps:
       - uses: actions/checkout@v3
 
@@ -202,38 +218,36 @@ jobs:
           cd crates/tanoshi
           cargo tauri build
 
-      - name: Upload dist (ubuntu)
-        uses: actions/upload-artifact@v3
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        with:
-          name: tanoshi-desktop
-          path: |
-            target/release/bundle/**/*.deb
-            target/release/bundle/**/*.AppImage
-            !target/release/bundle/**/linuxdeploy-x86_64.AppImage
+      - name: Move files (linux/macOS)
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
+        run: |
+          mkdir -p builds
+          find target/release/bundle/ -type f \( -name "*.deb" -o -name "*.AppImage" -o -name "*.dmg" \) -print0 |
+          while IFS= read -r -d '' file; do
+              mv "$file" ${{ github.workspace }}/builds/
+          done
 
-      - name: Upload dist (macos)
-        uses: actions/upload-artifact@v3
-        if: ${{ matrix.os == 'macos-latest' }}
-        with:
-          name: tanoshi-desktop
-          path: target/release/bundle/**/*.dmg
-
-      - name: Upload dist (windows)
-        uses: actions/upload-artifact@v3
+      - name: Move files (windows)
         if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          mkdir -p builds
+          mv target/release/bundle/msi/*.msi ${{ github.workspace }}/builds/
+
+      - name: Upload dist
+        uses: actions/upload-artifact@v3
         with:
           name: tanoshi-desktop
-          path: target/release/bundle/**/*.msi
+          path: ${{ github.workspace }}/builds/
 
       - name: Upload binaries to GitHub Releases
         if: startsWith(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/release/bundle/**/*
+          file: ${{ github.workspace }}/builds/*
           tag: ${{ github.ref }}
           file_glob: true
+          overwrite: true
 
   build-cli:
     runs-on: ubuntu-latest

--- a/crates/tanoshi-web/Cargo.toml
+++ b/crates/tanoshi-web/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4"
 wasm-logger = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 graphql_client = "0.12"
-wasm-bindgen = "=0.2.80"
+wasm-bindgen = "=0.2.87"
 wasm-bindgen-futures = "0.4"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"

--- a/crates/tanoshi-web/Trunk.toml
+++ b/crates/tanoshi-web/Trunk.toml
@@ -9,8 +9,9 @@ ws = true
 backend = "http://localhost:3030/image"
 
 [tools]
-sass = "1.50.0"
-wasm_bindgen = "0.2.80"
+sass = "1.62.1"
+wasm_bindgen = "0.2.87"
+# Pin to version of binaryen in tanoshi-builder
 wasm_opt = "version_108"
 
 [serve]


### PR DESCRIPTION
Fixes uploading the tanoshi-deskop files on releases
Updates rust to 1.71.1
Updates tanoshi-web dependencies