### PR TITLE
Revert rust-argon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.1]
+- [tanoshi] Revert rust-argon2 to version 1
+
 ## [0.32.0]
 - [tanoshi-vm] Output dummy source if no source found
 - [tanoshi-web] Add Select unread button to manga page

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,8 +1792,19 @@ checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
  "futures-core",
  "futures-sink",
- "nanorand",
  "pin-project",
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
  "spin 0.9.8",
 ]
 
@@ -4378,20 +4389,21 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "2.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e71971821b3ae0e769e4a4328dbcb517607b434db7697e9aba17203ec14e46a"
+checksum = "a5885493fdf0be6cdff808d1533ce878d21cfa49c7086fa00c66355cd9141bfc"
 dependencies = [
  "base64 0.21.2",
  "blake2b_simd",
  "constant_time_eq 0.3.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "rust-embed"
-version = "6.8.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36224c3276f8c4ebc8c20f158eca7ca4359c8db89991c4925132aaaf6702661"
+checksum = "b1e7d90385b59f0a6bf3d3b757f3ca4ece2048265d70db20a2016043d4509a40"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -4400,9 +4412,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "6.8.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b94b81e5b2c284684141a2fb9e2a31be90638caf040bf9afbc5a0416afe1ac"
+checksum = "3c3d8c6fd84090ae348e63a84336b112b5c3918b3bf0493a581f7bd8ee623c29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4414,9 +4426,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "7.8.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
+checksum = "873feff8cb7bf86fdf0a71bb21c95159f4e4a37dd7a4bd1855a940909b583ada"
 dependencies = [
  "sha2",
  "walkdir",
@@ -4995,7 +5007,7 @@ dependencies = [
  "dotenvy",
  "either",
  "event-listener",
- "flume",
+ "flume 0.10.14",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -5222,7 +5234,7 @@ checksum = "20f34339676cdcab560c9a82300c4c2581f68b9369aedf0fae86f2ff9565ff3e"
 
 [[package]]
 name = "tanoshi"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -5240,7 +5252,7 @@ dependencies = [
  "dirs 5.0.1",
  "env_logger 0.10.0",
  "fancy-regex",
- "flume",
+ "flume 0.11.0",
  "futures",
  "headers",
  "http",

--- a/crates/tanoshi/Cargo.toml
+++ b/crates/tanoshi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tanoshi"
-version = "0.32.0"
+version = "0.32.1"
 edition = "2021"
 description = "Tanoshi"
 repository = "https://github.com/luigi311/tanoshi"
@@ -28,7 +28,7 @@ tanoshi-vm = { path = "../tanoshi-vm" }
 tanoshi-tracker = { path = "../tanoshi-tracker" }
 tanoshi-notifier = { path = "../tanoshi-notifier" }
 tokio = { version = "1", features = ["full"] }
-tokio-stream = { version = "0.1.14", features = ["sync"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
@@ -57,7 +57,7 @@ jsonwebtoken = "8"
 chrono = { version = "0.4", features = ["serde"] }
 anyhow = "1"
 thiserror = "1"
-rust-embed = { version = "6.8", features = [
+rust-embed = { version = "8", features = [
     "interpolate-folder-path",
 ], optional = true }
 mime_guess = "2"
@@ -74,7 +74,7 @@ sqlx = { version = "0.6", features = [
 ] }
 reqwest = { version = "0.11", features = ["json"] }
 futures = "0.3"
-rust-argon2 = "2"
+rust-argon2 = "1"
 fancy-regex = "0.11"
 compress-tools = { git = "https://github.com/luigi311/compress-tools-rs", features = [
     "static",
@@ -88,4 +88,4 @@ once_cell = "1.18"
 async-trait = "0.1"
 itertools = "0.11"
 rayon = "1.7"
-flume = "0.10"
+flume = "0.11"

--- a/crates/tanoshi/src-tauri/tauri.conf.json
+++ b/crates/tanoshi/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "package": {
     "productName": "Tanoshi",
-    "version": "0.30.0"
+    "version": "0.32.1"
   },
   "build": {
     "distDir": "../../tanoshi-web/dist",


### PR DESCRIPTION
Temporary revert rust-argon to version 1 while more time is spent on moving to rust-argon=2 or argon2=0.5 depending on the research. 

Looks like rust-argon 2 updated the defaults to be more in line with the official argon2 standard which is way more cpu and memory intensive causing big spikes of 2gb each time someone tries to login which can be spammed multiple times to crash the server. 

Related #14  