### PR TITLE
Add Select Previous, Remove more popups

### DIFF
--- a/crates/tanoshi-web/src/library.rs
+++ b/crates/tanoshi-web/src/library.rs
@@ -291,6 +291,10 @@ impl Library {
         Self::fetch_category_detail(library.clone());
 
         html!("div", {
+            // Prevent context menu so mobile users dont get a popup
+            .event_with_options(&EventOptions::preventable(), clone!(library => move |e: events::ContextMenu| {
+                e.prevent_default();
+            }))
             .future(library.library_settings.sort.signal_cloned().for_each(clone!(library => move |sort| {
                 let mut covers = library.cover_list.lock_ref().to_vec();
                 covers.sort_by(|a, b| match sort {

--- a/crates/tanoshi-web/src/manga.rs
+++ b/crates/tanoshi-web/src/manga.rs
@@ -380,7 +380,7 @@ impl Manga {
                     .style("display", "flex")
                     .style("align-items", "center")
                     .text_signal(manga.selected_chapters.signal_vec_keys().len().map(clone!(manga => move |selected_len| {
-                        if selected_len == manga.chapters.lock_mut().len() {
+                        if selected_len > 0 {
                             "Deselect all"
                         } else {
                             "Select all"
@@ -389,7 +389,7 @@ impl Manga {
                     .event(clone!(manga => move |_: events::Click| {
                         let chapters = manga.chapters.lock_ref();
                         let mut selected_chapters = manga.selected_chapters.lock_mut();
-                        if selected_chapters.len() == chapters.len() {
+                        if selected_chapters.len() > 0 {
                             selected_chapters.clear();
                         } else {
                             // Only select visible chapters

--- a/crates/tanoshi-web/src/manga.rs
+++ b/crates/tanoshi-web/src/manga.rs
@@ -753,6 +753,10 @@ impl Manga {
         html!("div", {
             .class("chapter-list")
             .attr("id", "chapters")
+            // Prevent context menu so mobile users dont get a popup
+            .event_with_options(&EventOptions::preventable(), clone!(manga => move |e: events::ContextMenu| {
+                e.prevent_default();
+            }))
             .children(&mut [
                 html!("div", {
                     .style("display", "flex")


### PR DESCRIPTION
Adds select previous to help with #8
Removes more popups such as when you press and hold on a manga in the library and in the chapter list 