### PR TITLE
Docker: Change image to ubuntu 24.04

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
-	"image": "ghcr.io/luigi311/tanoshi-builder:sha-6b8a514-slim",
+	"image": "ghcr.io/luigi311/tanoshi-builder:sha-172c475-slim",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	//"features": {},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
   build-cli:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/luigi311/tanoshi-builder:sha-6b8a514-slim
+      image: ghcr.io/luigi311/tanoshi-builder:sha-172c475-slim
     steps:
       - uses: actions/checkout@v4
 
@@ -115,7 +115,7 @@ jobs:
   build-web:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/luigi311/tanoshi-builder:sha-6b8a514-slim
+      image: ghcr.io/luigi311/tanoshi-builder:sha-172c475-slim
     steps:
       - uses: actions/checkout@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/luigi311/tanoshi-builder:sha-6b8a514-slim AS base
+FROM ghcr.io/luigi311/tanoshi-builder:sha-172c475-slim AS base
 
 # Backend builder
 FROM base AS builder
@@ -11,7 +11,7 @@ RUN cargo build -p tanoshi --release
 
 
 
-FROM debian:bookworm-slim AS runtime
+FROM ubuntu:24.04 AS runtime
 
 RUN apt update && apt upgrade -y && apt install --reinstall -y tini ca-certificates libssl3 libxml2
 

--- a/Dockerfile.CI
+++ b/Dockerfile.CI
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS runtime
+FROM ubuntu:24.04 AS runtime
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 


### PR DESCRIPTION
Use ubuntu as the base image to avoid issues where the CI building tools are incompatible with the debian docker image i was using before.