### PR TITLE
Potential fix for code scanning alert no. 63: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,8 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       - build-tanoshi
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/luigi311/tanoshi/security/code-scanning/63](https://github.com/luigi311/tanoshi/security/code-scanning/63)

To fix the problem, add a `permissions` block to the `docker` job at line 357 in `.github/workflows/ci.yml`, restricting its GITHUB_TOKEN access as much as possible. The minimal starting point is usually:

```yaml
permissions:
  contents: read
```

If the job needs additional permissions for e.g. uploading packages, releases, or interacting with issues, you should add those specifically as needed (`packages: write`, `pull-requests: write`, etc.), but in this case the job appears to only require read access to repository contents. Place the `permissions` block immediately below the `runs-on` key for this job and indented at the same level as other job properties.

No new imports or method definitions are required: this is a pure YAML change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
