### PR TITLE
Add proper rate limiting to download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6752,7 +6752,7 @@ dependencies = [
 
 [[package]]
 name = "tanoshi-lib"
-version = "0.27.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "rustc_version",
@@ -6809,7 +6809,7 @@ dependencies = [
 
 [[package]]
 name = "tanoshi-vm"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/crates/tanoshi-lib/Cargo.toml
+++ b/crates/tanoshi-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tanoshi-lib"
-version = "0.27.0"
+version = "0.38.0"
 edition = "2024"
 rust-version = "1.90.0"
 description = "Tanoshi library"

--- a/crates/tanoshi-lib/src/extensions.rs
+++ b/crates/tanoshi-lib/src/extensions.rs
@@ -57,7 +57,7 @@ pub trait PluginRegistrar {
 macro_rules! export_plugin {
     ($register:expr_2021) => {
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub static plugin_declaration: $crate::extensions::PluginDeclaration =
             $crate::extensions::PluginDeclaration {
                 rustc_version: $crate::RUSTC_VERSION,

--- a/crates/tanoshi-lib/src/models/source_info.rs
+++ b/crates/tanoshi-lib/src/models/source_info.rs
@@ -18,4 +18,5 @@ pub struct SourceInfo {
     pub icon: &'static str,
     pub languages: Lang,
     pub nsfw: bool,
+    pub requests_per_second: Option<f64>,
 }

--- a/crates/tanoshi-vm/Cargo.toml
+++ b/crates/tanoshi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tanoshi-vm"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.90.0"
 description = "Tanoshi VM"

--- a/crates/tanoshi-vm/src/extension/manager.rs
+++ b/crates/tanoshi-vm/src/extension/manager.rs
@@ -25,6 +25,7 @@ pub fn dummy_source_info(id: i64) -> SourceInfo {
         icon: "",
         languages: Lang::All,
         nsfw: false,
+        requests_per_second: None,
     }
 }
 

--- a/crates/tanoshi/src/application/worker/updates.rs
+++ b/crates/tanoshi/src/application/worker/updates.rs
@@ -65,6 +65,7 @@ pub struct SourceInfo {
     pub version: String,
     pub icon: String,
     pub nsfw: bool,
+    pub requests_per_second: Option<f64>,
 }
 
 struct UpdatesWorker<C, M, L>

--- a/crates/tanoshi/src/infrastructure/local.rs
+++ b/crates/tanoshi/src/infrastructure/local.rs
@@ -244,6 +244,7 @@ impl Extension for Local {
             icon: "/icons/192.png",
             languages: Lang::All,
             nsfw: false,
+            requests_per_second: None,
         }
     }
 


### PR DESCRIPTION
This is a breaking change and will require publishing a new tanoshi-lib crate as this will add a requests_per_second field to the SourceInfo type and as such will also require extensions to be updated to add in that requests per second field.

This is set to amount of requests per second and a safe default value for extensions will probably be 1 rps. the requests per second field is an Option as its possible for some sources to not have a limit so no sense in forcing a delay.

The current implementation requires reading the source information on each download step, in the future it would be better to instead adjust the downloadqueue table to include a delay column that contains the amount to delay by that way it only has to be calculated once per chapter inserted into the queue instead of calculated on each page download.