### PR TITLE
Upgrade rust to 1.93.1

### DIFF
--- a/crates/tanoshi-cli/Cargo.toml
+++ b/crates/tanoshi-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tanoshi-cli"
 version = "0.7.0"
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.93.1"
 description = "Tanoshi CLI Utilities"
 repository = "https://github.com/luigi311/tanoshi"
 license = "MIT"

--- a/crates/tanoshi-lib/Cargo.toml
+++ b/crates/tanoshi-lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tanoshi-lib"
 version = "0.38.0"
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.93.1"
 description = "Tanoshi library"
 repository = "https://github.com/luigi311/tanoshi"
 license = "MIT"

--- a/crates/tanoshi-notifier/Cargo.toml
+++ b/crates/tanoshi-notifier/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tanoshi-notifier"
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.93.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/tanoshi-schema/Cargo.toml
+++ b/crates/tanoshi-schema/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tanoshi-schema"
 version = "0.1.1"
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.93.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/tanoshi-tauri/Cargo.toml
+++ b/crates/tanoshi-tauri/Cargo.toml
@@ -3,7 +3,7 @@ name = "tanoshi-app"
 version = "0.37.1"
 default-run = "tanoshi-app"
 edition = "2021"
-rust-version = "1.90.0"
+rust-version = "1.93.1"
 build = "src/build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/tanoshi-tracker/Cargo.toml
+++ b/crates/tanoshi-tracker/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tanoshi-tracker"
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.93.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/tanoshi-util/Cargo.toml
+++ b/crates/tanoshi-util/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tanoshi-util"
 version = "0.3.0"
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.93.1"
 description = "Tanoshi Utilities"
 repository = "https://github.com/luigi311/tanoshi"
 license = "MIT"

--- a/crates/tanoshi-vm/Cargo.toml
+++ b/crates/tanoshi-vm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tanoshi-vm"
 version = "0.8.0"
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.93.1"
 description = "Tanoshi VM"
 repository = "https://github.com/luigi311/tanoshi"
 license = "MIT"

--- a/crates/tanoshi-web/Cargo.toml
+++ b/crates/tanoshi-web/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tanoshi-web"
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.93.1"
 description = "Tanoshi Web"
 repository = "https://github.com/luigi311/tanoshi"
 license = "MIT"

--- a/crates/tanoshi/Cargo.toml
+++ b/crates/tanoshi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tanoshi"
 version = "0.37.1"
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.93.1"
 description = "Tanoshi"
 repository = "https://github.com/luigi311/tanoshi"
 license = "MIT"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,5 +3,5 @@
 # 1st https://github.com/luigi311/tanoshi-builder
 # 2nd Here and then create a release
 # 3rd https://github.com/luigi311/tanoshi-extensions
-channel = "1.90.0"
+channel = "1.93.1"
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
This upgrade is more to avoid issues with the breaking changes in #68 so the extensions will be split between 0.37 and 0.38