### PR TITLE
Add manga migration feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6846,6 +6846,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tanoshi-schema",
+ "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-logger",
@@ -8015,6 +8016,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"

--- a/crates/tanoshi-schema/graphql/migrate_manga.graphql
+++ b/crates/tanoshi-schema/graphql/migrate_manga.graphql
@@ -1,0 +1,3 @@
+mutation MigrateManga($mangaId: Int!, $toSourceId: Int!, $toPath: String!) {
+  migrateManga(mangaId: $mangaId, toSourceId: $toSourceId, toPath: $toPath)
+}

--- a/crates/tanoshi-schema/graphql/schema.graphql
+++ b/crates/tanoshi-schema/graphql/schema.graphql
@@ -117,6 +117,20 @@ type MutationRoot {
     # manga id
     mangaId: Int!
   ): Int!
+
+  # Migrate a manga to another source: moves the library entry with its
+  # categories, read progress and trackers to the manga at `to_path` on
+  # `to_source_id`. Returns the destination manga id.
+  migrateManga(
+    # manga id to migrate from
+    mangaId: Int!
+
+    # destination source id
+    toSourceId: Int!
+
+    # destination manga path
+    toPath: String!
+  ): Int!
   updatePageReadAt(
     # chapter id
     chapterId: Int!

--- a/crates/tanoshi-schema/src/lib.rs
+++ b/crates/tanoshi-schema/src/lib.rs
@@ -90,6 +90,14 @@ pub struct DeleteFromLibrary;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "graphql/schema.graphql",
+    query_path = "graphql/migrate_manga.graphql",
+    response_derives = "Debug"
+)]
+pub struct MigrateManga;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
     query_path = "graphql/fetch_category_detail.graphql",
     response_derives = "Debug"
 )]

--- a/crates/tanoshi-web/Cargo.toml
+++ b/crates/tanoshi-web/Cargo.toml
@@ -37,6 +37,7 @@ graphql-ws-client = { version = "0.11", features = [
     "client-graphql-client",
     "ws_stream_wasm",
 ] }
+urlencoding = "2"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/crates/tanoshi-web/src/catalogue.rs
+++ b/crates/tanoshi-web/src/catalogue.rs
@@ -95,9 +95,20 @@ impl Catalogue {
                 ..Default::default()
             });
 
-        // If the restored state belongs to a different source, discard
-        // source-specific fields so we don't flash stale data.
-        if catalogue.source_id != source_id {
+        // Consume the migration state on first entry so it isn't restored on
+        // a later revisit. The Cancel button and successful migrate_to both
+        // also call migration::clear().
+        let ms = migration::get();
+        let entering_migrate_mode = ms.as_ref().is_some_and(|s| s.to_source_id == source_id);
+        if entering_migrate_mode {
+            migration::clear();
+        }
+
+        // Discard source-specific fields when the restored state belongs to a
+        // different source (don't flash stale data), or when entering migrate
+        // mode: render() only fetches when cover_list is empty, so a cached
+        // same-source grid would otherwise shadow the prefilled search query.
+        if catalogue.source_id != source_id || entering_migrate_mode {
             catalogue.cover_list = MutableVec::new();
             catalogue.page = Mutable::new(1);
             catalogue.latest = Mutable::new(false);
@@ -108,14 +119,6 @@ impl Catalogue {
         catalogue.source_id = source_id;
 
         let rc = Rc::new(catalogue);
-
-        // Consume the migration state on first entry so it isn't restored on
-        // a later revisit. The Cancel button and successful migrate_to both
-        // also call migration::clear().
-        let ms = migration::get();
-        if ms.as_ref().is_some_and(|s| s.to_source_id == source_id) {
-            migration::clear();
-        }
         rc.migration_state.set(ms);
         rc
     }

--- a/crates/tanoshi-web/src/catalogue.rs
+++ b/crates/tanoshi-web/src/catalogue.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 
 use crate::{
     common::{snackbar, Cover, InputList, Spinner},
+    migration,
     query,
     utils::{history, local_storage, window, AsyncLoader},
 };
@@ -57,6 +58,10 @@ pub struct Catalogue {
     loader: AsyncLoader,
     #[serde(skip)]
     spinner: Rc<Spinner>,
+    #[serde(skip)]
+    migration_state: Mutable<Option<migration::MigrationState>>,
+    #[serde(skip)]
+    pending_migration: Mutable<Option<Cover>>,
 }
 
 impl Default for Catalogue {
@@ -73,13 +78,15 @@ impl Default for Catalogue {
             input_list_modal: Rc::new(InputList::new(true)),
             spinner: Spinner::new(),
             loader: AsyncLoader::new(),
+            migration_state: Mutable::new(None),
+            pending_migration: Mutable::new(None),
         }
     }
 }
 
 impl Catalogue {
     pub fn new(source_id: i64) -> Rc<Self> {
-        let catalogue = local_storage()
+        let mut catalogue = local_storage()
             .get(STORAGE_KEY)
             .unwrap_throw()
             .and_then(|object_str| serde_json::from_str(&object_str).ok())
@@ -88,7 +95,12 @@ impl Catalogue {
                 ..Default::default()
             });
 
-        Rc::new(catalogue)
+        // ensure source_id matches the route when restoring from storage
+        catalogue.source_id = source_id;
+
+        let rc = Rc::new(catalogue);
+        rc.migration_state.set(migration::get());
+        rc
     }
 
     pub fn serialize_into_json(&self) -> String {
@@ -354,45 +366,94 @@ impl Catalogue {
     }
 
     pub fn render_main(catalogue: Rc<Self>) -> Dom {
+        use futures_signals::signal::SignalExt;
+
+        let is_migrate_mode_signal = catalogue
+            .migration_state
+            .signal_cloned()
+            .map(clone!(catalogue => move |ms| {
+                ms.as_ref()
+                    .map(|s| s.to_source_id == catalogue.source_id)
+                    .unwrap_or(false)
+            }));
+
         html!("div", {
             .style("padding", "0.5rem")
             .children(&mut [
+                // IMPORTANT: the child_signal returns the manga-grid itself
                 html!("div", {
-                    .class("manga-grid")
-                    .children_signal_vec(catalogue.cover_list.signal_vec_cloned().map(|cover| cover.render()))
+                    .child_signal(is_migrate_mode_signal.map(clone!(catalogue => move |is_migrate_mode| {
+                        if is_migrate_mode {
+                            Some(html!("div", {
+                                .class("manga-grid")
+                                .children_signal_vec(
+                                    catalogue.cover_list.signal_vec_cloned().map(clone!(catalogue => move |cover| {
+                                        html!("div", {
+                                            .class("manga-cover")
+                                            .class("animate__animated")
+                                            .class("animate__faster")
+                                            .class("animate__fadeIn")
+                                            .event(clone!(catalogue, cover => move |_: events::Click| {
+                                                Catalogue::confirm_migration_target(catalogue.clone(), cover.clone());
+                                            }))
+                                            .children(&mut [
+                                                html!("img", {
+                                                    .attr("src", &cover.cover_url)
+                                                    .attr("loading", "lazy")
+                                                }),
+                                                html!("div", {
+                                                    .class("title")
+                                                    .child(html!("span", { .text(&cover.title) }))
+                                                })
+                                            ])
+                                        })
+                                    }))
+                                )
+                            }))
+                        } else {
+                            Some(html!("div", {
+                                .class("manga-grid")
+                                .children_signal_vec(
+                                    catalogue.cover_list
+                                        .signal_vec_cloned()
+                                        .map(|cover| cover.render())
+                                )
+                            }))
+                        }
+                    })))
                 }),
+
                 html!("div", {
                     .class("load-more-btn")
-                    .child_signal(catalogue.spinner.signal().map(clone!(catalogue => move |x| if x {
-                        Some(Spinner::render(catalogue.spinner.clone()))
-                    } else {
-                        Some(html!("button", {
-                            .text("Load More")
-                            .event(clone!(catalogue => move |_: events::Click| {
-                                catalogue.page.set(catalogue.page.get() + 1);
-                                Self::fetch_mangas(catalogue.clone());
+                    .child_signal(catalogue.spinner.signal().map(clone!(catalogue => move |x| {
+                        if x {
+                            Some(Spinner::render(catalogue.spinner.clone()))
+                        } else {
+                            Some(html!("button", {
+                                .text("Load More")
+                                .event(clone!(catalogue => move |_: events::Click| {
+                                    catalogue.page.set(catalogue.page.get() + 1);
+                                    Self::fetch_mangas(catalogue.clone());
+                                }))
                             }))
-                        }))
+                        }
                     })))
-                })
+                }),
             ])
         })
     }
 
     pub fn render(self: Rc<Self>, latest: bool, query: Option<String>) -> Dom {
-        if self.cover_list.lock_ref().is_empty() {
-            Self::fetch_mangas(self.clone());
-        }
-
-        // let s = map_ref! {
-        //     let keyword = self.keyword.signal_cloned(),
-
-        //     (keyword.clone())
-        // };
+        // refresh migration state every time we render
+        self.migration_state.set_neq(migration::get());
 
         self.is_search.set_neq(query.is_some());
         self.keyword.set_neq(query);
         self.latest.set_neq(latest);
+
+        if self.cover_list.lock_ref().is_empty() {
+            Self::fetch_mangas(self.clone());
+        }
 
         html!("div", {
             .future(self.keyword.signal_cloned().for_each({
@@ -409,8 +470,48 @@ impl Catalogue {
                     .class("topbar-spacing")
                 })
             ])
+            .child_signal(self.migration_state.signal_cloned().map({
+                let catalogue = self.clone();
+                move |ms| {
+                    let show = ms.as_ref().map(|s| s.to_source_id == catalogue.source_id).unwrap_or(false);
+                    show.then(|| html!("div", {
+                        .style("margin", "0.5rem")
+                        .style("padding", "0.5rem 0.75rem")
+                        .style("border-radius", "0.5rem")
+                        .style("background", "rgba(255,255,255,0.06)")
+                        .style("display", "flex")
+                        .style("justify-content", "space-between")
+                        .style("align-items", "center")
+                        .children(&mut [
+                            html!("div", {
+                                .style("display", "flex")
+                                .style("flex-direction", "column")
+                                .children(&mut [
+                                    html!("span", { .text("Migration mode") }),
+                                    html!("span", {
+                                        .style("font-size", "0.875rem")
+                                        .style("opacity", "0.85")
+                                        .text(ms.as_ref().map(|s| format!("Select the destination manga for: {}", s.from_title)).unwrap_or_default().as_str())
+                                    })
+                                ])
+                            }),
+                            html!("button", {
+                                .text("Cancel")
+                                .event({
+                                    let catalogue = catalogue.clone();
+                                    move |_: events::Click| {
+                                        migration::clear();
+                                        catalogue.migration_state.set_neq(None);
+                                    }
+                                })
+                            })
+                        ])
+                    }))
+                }
+            }))
             .children(&mut [
                 Self::render_main(self.clone()),
+                Self::render_migration_confirm_modal(self.clone()),
                 InputList::render(self.input_list_modal.clone(), {
                     let catalogue = self.clone();
                     move || {
@@ -425,6 +526,101 @@ impl Catalogue {
                     .class("bottombar-spacing")
                 })
             ])
+        })
+    }
+
+    // window.confirm doesn't work in the tauri webview (the dialog plugin
+    // replaces it with an async version), so confirmation is an in-app modal.
+    pub fn confirm_migration_target(catalogue: Rc<Self>, to_cover: Cover) {
+        let valid = catalogue
+            .migration_state
+            .get_cloned()
+            .is_some_and(|s| s.to_source_id == catalogue.source_id);
+        if valid {
+            catalogue.pending_migration.set(Some(to_cover));
+        }
+    }
+
+    fn migrate_to(catalogue: Rc<Self>, to_cover: Cover) {
+        let Some(ms) = catalogue.migration_state.get_cloned() else {
+            return;
+        };
+
+        catalogue.spinner.set_active(true);
+        catalogue.loader.load(clone!(catalogue => async move {
+            // Migrate by source path: browse covers may not be in the database
+            // yet, so their id can be 0.
+            match query::migrate_manga(ms.from_manga_id, catalogue.source_id, to_cover.path.clone()).await {
+                Ok(to_manga_id) => {
+                    snackbar::show("Migration complete".to_string());
+                    migration::clear();
+                    catalogue.migration_state.set_neq(None);
+
+                    // Go directly to the migrated manga
+                    routing::go_to_url(&crate::common::Route::Manga(to_manga_id).url());
+                }
+                Err(e) => {
+                    snackbar::show(format!("Migration failed: {e}"));
+                }
+            }
+            catalogue.spinner.set_active(false);
+        }));
+    }
+
+    fn render_migration_confirm_modal(catalogue: Rc<Self>) -> Dom {
+        html!("div", {
+            .child_signal(catalogue.pending_migration.signal_cloned().map(clone!(catalogue => move |pending| {
+                pending.map(|to_cover| {
+                    let from_title = catalogue
+                        .migration_state
+                        .get_cloned()
+                        .map(|s| s.from_title)
+                        .unwrap_or_default();
+
+                    html!("div", {
+                        .style("position", "fixed")
+                        .style("inset", "0")
+                        .style("background", "rgba(0,0,0,0.5)")
+                        .style("z-index", "9999")
+                        .child(html!("div", {
+                            .style("background", "var(--bg, white)")
+                            .style("border-radius", "0.75rem")
+                            .style("max-width", "32rem")
+                            .style("margin", "10vh auto")
+                            .style("padding", "1rem")
+                            .children(&mut [
+                                html!("h3", {
+                                    .style("margin", "0 0 0.5rem 0")
+                                    .text("Confirm migration")
+                                }),
+                                html!("div", { .text(format!("From: {from_title}").as_str()) }),
+                                html!("div", { .text(format!("To: {}", to_cover.title).as_str()) }),
+                                html!("div", {
+                                    .style("display", "flex")
+                                    .style("justify-content", "flex-end")
+                                    .style("gap", "0.5rem")
+                                    .style("margin-top", "0.75rem")
+                                    .children(&mut [
+                                        html!("button", {
+                                            .text("Cancel")
+                                            .event(clone!(catalogue => move |_: events::Click| {
+                                                catalogue.pending_migration.set(None);
+                                            }))
+                                        }),
+                                        html!("button", {
+                                            .text("Migrate")
+                                            .event(clone!(catalogue, to_cover => move |_: events::Click| {
+                                                catalogue.pending_migration.set(None);
+                                                Self::migrate_to(catalogue.clone(), to_cover.clone());
+                                            }))
+                                        })
+                                    ])
+                                })
+                            ])
+                        }))
+                    })
+                })
+            })))
         })
     }
 }

--- a/crates/tanoshi-web/src/catalogue.rs
+++ b/crates/tanoshi-web/src/catalogue.rs
@@ -615,7 +615,9 @@ impl Catalogue {
                         .style("background", "rgba(0,0,0,0.5)")
                         .style("z-index", "9999")
                         .child(html!("div", {
-                            .style("background", "var(--bg, white)")
+                            .style("background", "var(--modal-background-color)")
+                            .style("color", "var(--color)")
+                            .style("box-shadow", "var(--shadow)")
                             .style("border-radius", "0.75rem")
                             .style("max-width", "32rem")
                             .style("margin", "10vh auto")

--- a/crates/tanoshi-web/src/catalogue.rs
+++ b/crates/tanoshi-web/src/catalogue.rs
@@ -7,7 +7,7 @@ use crate::{
     utils::{history, local_storage, window, AsyncLoader},
 };
 use dominator::{clone, events, html, routing, svg, with_node, Dom, EventOptions};
-use futures_signals::signal::{Mutable, SignalExt};
+use futures_signals::signal::{Mutable, Signal, SignalExt};
 use futures_signals::signal_vec::{MutableVec, SignalVecExt};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::{JsValue, UnwrapThrowExt};
@@ -95,11 +95,28 @@ impl Catalogue {
                 ..Default::default()
             });
 
-        // ensure source_id matches the route when restoring from storage
+        // If the restored state belongs to a different source, discard
+        // source-specific fields so we don't flash stale data.
+        if catalogue.source_id != source_id {
+            catalogue.cover_list = MutableVec::new();
+            catalogue.page = Mutable::new(1);
+            catalogue.latest = Mutable::new(false);
+            catalogue.keyword = Mutable::new(None);
+            catalogue.is_filter = Mutable::new(false);
+        }
+
         catalogue.source_id = source_id;
 
         let rc = Rc::new(catalogue);
-        rc.migration_state.set(migration::get());
+
+        // Consume the migration state on first entry so it isn't restored on
+        // a later revisit. The Cancel button and successful migrate_to both
+        // also call migration::clear().
+        let ms = migration::get();
+        if ms.as_ref().is_some_and(|s| s.to_source_id == source_id) {
+            migration::clear();
+        }
+        rc.migration_state.set(ms);
         rc
     }
 
@@ -181,7 +198,8 @@ impl Catalogue {
             let mut param = vec![];
 
             if let Some(query) = self.keyword.get_cloned() {
-                param.push(format!("query={}", query));
+                let q = urlencoding::encode(&query);
+                param.push(format!("query={}", q));
             };
 
             // if let Ok(filters) = serde_json::to_string(&self.input_list_modal.input_list) {
@@ -365,17 +383,29 @@ impl Catalogue {
         })
     }
 
+    fn is_migrate_mode(&self) -> bool {
+        self.migration_state
+            .get_cloned()
+            .as_ref()
+            .map(|s| s.to_source_id == self.source_id)
+            .unwrap_or(false)
+    }
+
+    fn migrate_mode_signal(&self) -> impl Signal<Item = bool> + use<> {
+        let source_id = self.source_id;
+        self.migration_state
+            .signal_cloned()
+            .map(move |ms| {
+                ms.as_ref()
+                    .map(|s| s.to_source_id == source_id)
+                    .unwrap_or(false)
+            })
+    }
+
     pub fn render_main(catalogue: Rc<Self>) -> Dom {
         use futures_signals::signal::SignalExt;
 
-        let is_migrate_mode_signal = catalogue
-            .migration_state
-            .signal_cloned()
-            .map(clone!(catalogue => move |ms| {
-                ms.as_ref()
-                    .map(|s| s.to_source_id == catalogue.source_id)
-                    .unwrap_or(false)
-            }));
+        let is_migrate_mode_signal = catalogue.migrate_mode_signal();
 
         html!("div", {
             .style("padding", "0.5rem")
@@ -444,9 +474,8 @@ impl Catalogue {
     }
 
     pub fn render(self: Rc<Self>, latest: bool, query: Option<String>) -> Dom {
-        // refresh migration state every time we render
-        self.migration_state.set_neq(migration::get());
-
+        // migration_state is consumed from storage once in new(); don't
+        // re-read storage here or the consumed state would be wiped.
         self.is_search.set_neq(query.is_some());
         self.keyword.set_neq(query);
         self.latest.set_neq(latest);
@@ -470,43 +499,47 @@ impl Catalogue {
                     .class("topbar-spacing")
                 })
             ])
-            .child_signal(self.migration_state.signal_cloned().map({
+            .child_signal(self.migrate_mode_signal().map({
                 let catalogue = self.clone();
-                move |ms| {
-                    let show = ms.as_ref().map(|s| s.to_source_id == catalogue.source_id).unwrap_or(false);
-                    show.then(|| html!("div", {
-                        .style("margin", "0.5rem")
-                        .style("padding", "0.5rem 0.75rem")
-                        .style("border-radius", "0.5rem")
-                        .style("background", "rgba(255,255,255,0.06)")
-                        .style("display", "flex")
-                        .style("justify-content", "space-between")
-                        .style("align-items", "center")
-                        .children(&mut [
-                            html!("div", {
-                                .style("display", "flex")
-                                .style("flex-direction", "column")
-                                .children(&mut [
-                                    html!("span", { .text("Migration mode") }),
-                                    html!("span", {
-                                        .style("font-size", "0.875rem")
-                                        .style("opacity", "0.85")
-                                        .text(ms.as_ref().map(|s| format!("Select the destination manga for: {}", s.from_title)).unwrap_or_default().as_str())
-                                    })
-                                ])
-                            }),
-                            html!("button", {
-                                .text("Cancel")
-                                .event({
-                                    let catalogue = catalogue.clone();
-                                    move |_: events::Click| {
+                move |show| {
+                    show.then(|| {
+                        let from_title = catalogue
+                            .migration_state
+                            .get_cloned()
+                            .map(|s| s.from_title)
+                            .unwrap_or_default();
+
+                        html!("div", {
+                            .style("margin", "0.5rem")
+                            .style("padding", "0.5rem 0.75rem")
+                            .style("border-radius", "0.5rem")
+                            .style("background", "rgba(255,255,255,0.06)")
+                            .style("display", "flex")
+                            .style("justify-content", "space-between")
+                            .style("align-items", "center")
+                            .children(&mut [
+                                html!("div", {
+                                    .style("display", "flex")
+                                    .style("flex-direction", "column")
+                                    .children(&mut [
+                                        html!("span", { .text("Migration mode") }),
+                                        html!("span", {
+                                            .style("font-size", "0.875rem")
+                                            .style("opacity", "0.85")
+                                            .text(format!("Select the destination manga for: {from_title}").as_str())
+                                        })
+                                    ])
+                                }),
+                                html!("button", {
+                                    .text("Cancel")
+                                    .event(clone!(catalogue => move |_: events::Click| {
                                         migration::clear();
                                         catalogue.migration_state.set_neq(None);
-                                    }
+                                    }))
                                 })
-                            })
-                        ])
-                    }))
+                            ])
+                        })
+                    })
                 }
             }))
             .children(&mut [
@@ -532,11 +565,7 @@ impl Catalogue {
     // window.confirm doesn't work in the tauri webview (the dialog plugin
     // replaces it with an async version), so confirmation is an in-app modal.
     pub fn confirm_migration_target(catalogue: Rc<Self>, to_cover: Cover) {
-        let valid = catalogue
-            .migration_state
-            .get_cloned()
-            .is_some_and(|s| s.to_source_id == catalogue.source_id);
-        if valid {
+        if catalogue.is_migrate_mode() {
             catalogue.pending_migration.set(Some(to_cover));
         }
     }

--- a/crates/tanoshi-web/src/common/route.rs
+++ b/crates/tanoshi-web/src/common/route.rs
@@ -18,6 +18,7 @@ pub enum SettingCategory {
     CreateUser,
     User,
     DownloadQueue,
+    Migrate,
 }
 
 #[derive(Debug, Clone)]
@@ -68,7 +69,7 @@ impl Route {
                     ["catalogue", id] => {
                         if let Ok(id) = id.parse() {
                             let params = url.search_params();
-                            let query = params.get("keyword");
+                            let query = params.get("query").or_else(|| params.get("keyword"));
                             Route::Catalogue {
                                 id,
                                 latest: false,
@@ -81,7 +82,7 @@ impl Route {
                     ["catalogue", id, "latest"] => {
                         if let Ok(id) = id.parse() {
                             let params = url.search_params();
-                            let query = params.get("keyword");
+                            let query = params.get("query").or_else(|| params.get("keyword"));
                             Route::Catalogue {
                                 id,
                                 latest: true,
@@ -137,6 +138,7 @@ impl Route {
                         "users" => Route::Settings(SettingCategory::Users),
                         "user" => Route::Settings(SettingCategory::User),
                         "downloads-queue" => Route::Settings(SettingCategory::DownloadQueue),
+                        "migrate" => Route::Settings(SettingCategory::Migrate),
                         _ => Route::NotFound,
                     },
                     ["settings", "users", "create"] => Route::Settings(SettingCategory::CreateUser),
@@ -195,10 +197,15 @@ impl Route {
 
                 let mut param = vec![];
                 if let Some(query) = query {
-                    param.push(format!("query={query}"));
+                    let q = urlencoding::encode(query);
+                    param.push(format!("query={}", q));
                 }
 
-                format!("/catalogue/{id}?{}", param.join("&"))
+                if param.is_empty() {
+                    format!("/catalogue/{id}")
+                } else {
+                    format!("/catalogue/{id}?{}", param.join("&"))
+                }
             }
             Route::Manga(manga_id) => ["/manga".to_string(), manga_id.to_string()].join("/"),
             Route::MangaBySourcePath(source_id, path) => [
@@ -228,6 +235,7 @@ impl Route {
             Route::Settings(SettingCategory::DownloadQueue) => {
                 "/settings/downloads-queue".to_string()
             }
+            Route::Settings(SettingCategory::Migrate) => "/settings/migrate".to_string(),
             Route::TrackerLogin(tracker) => format!("/tracker/{tracker}/login"),
             Route::TrackerRedirect {
                 tracker,

--- a/crates/tanoshi-web/src/lib.rs
+++ b/crates/tanoshi-web/src/lib.rs
@@ -10,6 +10,7 @@ mod library;
 mod library_list;
 mod login;
 mod manga;
+mod migration;
 #[allow(dead_code)]
 mod query;
 mod reader;
@@ -17,6 +18,7 @@ mod settings;
 mod settings_categories;
 mod settings_download_queue;
 mod settings_manage_downloads;
+mod settings_migrate;
 mod settings_source;
 mod tracker_login;
 mod tracker_redirect;

--- a/crates/tanoshi-web/src/manga.rs
+++ b/crates/tanoshi-web/src/manga.rs
@@ -111,6 +111,7 @@ impl Manga {
                 }
             }
 
+            debug!("Fetching manga detail for manga id {} with refresh={}", manga.id.get(), refresh);
             match query::fetch_manga_detail(manga.id.get(), refresh).await {
                 Ok(result) => {
                     manga.source_id.set(result.source.id);

--- a/crates/tanoshi-web/src/migration.rs
+++ b/crates/tanoshi-web/src/migration.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::UnwrapThrowExt;
+
+use crate::utils::local_storage;
+
+pub const MIGRATION_KEY: &str = "migration:state";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MigrationState {
+    // What we are migrating FROM (usually in your library)
+    pub from_manga_id: i64,
+    pub from_source_id: i64,
+    pub from_title: String,
+
+    // Where we are migrating TO
+    pub to_source_id: i64,
+}
+
+pub fn set(state: &MigrationState) {
+    let json = serde_json::to_string(state).unwrap_throw();
+    local_storage().set(MIGRATION_KEY, &json).unwrap_throw();
+}
+
+pub fn get() -> Option<MigrationState> {
+    local_storage()
+        .get(MIGRATION_KEY)
+        .unwrap_throw()
+        .and_then(|s| serde_json::from_str(&s).ok())
+}
+
+pub fn clear() {
+    let _ = local_storage().delete(MIGRATION_KEY);
+}

--- a/crates/tanoshi-web/src/query.rs
+++ b/crates/tanoshi-web/src/query.rs
@@ -687,3 +687,22 @@ pub async fn refresh_chapters(manga_id: Option<i64>, wait: bool) -> Result<(), B
 
     Ok(())
 }
+
+/// Migrate a library manga to another source: the server moves the library
+/// entry (with categories), read progress, and trackers to the manga at
+/// `to_path` on `to_source_id` in one transaction. Returns the destination
+/// manga id.
+pub async fn migrate_manga(
+    from_manga_id: i64,
+    to_source_id: i64,
+    to_path: String,
+) -> Result<i64, Box<dyn Error>> {
+    let var = migrate_manga::Variables {
+        manga_id: from_manga_id,
+        to_source_id,
+        to_path,
+    };
+    let data = post_graphql::<MigrateManga>(var).await?;
+
+    Ok(data.migrate_manga)
+}

--- a/crates/tanoshi-web/src/settings.rs
+++ b/crates/tanoshi-web/src/settings.rs
@@ -15,7 +15,8 @@ use crate::{
     }, 
     query, 
     settings_categories::SettingsCategories, 
-    settings_download_queue::SettingsDownloads, 
+    settings_download_queue::SettingsDownloads,
+    settings_migrate::SettingsMigrate,
     utils::{AsyncLoader, is_tauri, window}, settings_source::SettingsSource
 };
 use dominator::svg;
@@ -308,7 +309,8 @@ impl Settings {
                             SettingCategory::Users => "Users",
                             SettingCategory::CreateUser => "Create User",
                             SettingCategory::User => "User",
-                            SettingCategory::DownloadQueue => "Downloads Queue"
+                            SettingCategory::DownloadQueue => "Downloads Queue",
+                            SettingCategory::Migrate => "Migrate Manga"
                         }
                     ))
                 }),
@@ -411,7 +413,11 @@ impl Settings {
                 link!(Route::Settings(SettingCategory::SourceList).url(), {
                     .class("list-item")
                     .text("Sources")
-                })
+                }),
+                link!(Route::Settings(SettingCategory::Migrate).url(), {
+                    .class("list-item")
+                    .text("Migrate Manga")
+                }),
             ])
             .child_signal(settings.me.signal_cloned().map(|me| {
                 if let Some(me) = me {
@@ -797,6 +803,7 @@ impl Settings {
                     SettingCategory::User => Some(Profile::render(Profile::new())),
                     SettingCategory::CreateUser => Some(Login::render(Login::new())),
                     SettingCategory::DownloadQueue => Some(SettingsDownloads::render(SettingsDownloads::new())),
+                    SettingCategory::Migrate => Some(SettingsMigrate::render(SettingsMigrate::new())),
                 }
             }))            
         })

--- a/crates/tanoshi-web/src/settings_migrate.rs
+++ b/crates/tanoshi-web/src/settings_migrate.rs
@@ -250,7 +250,9 @@ impl SettingsMigrate {
 
                             .child(html!("div", {
                                 // Modal card
-                                .style("background", "var(--bg, white)")
+                                .style("background", "var(--modal-background-color)")
+                                .style("color", "var(--color)")
+                                .style("box-shadow", "var(--shadow)")
                                 .style("border-radius", "0.75rem")
                                 .style("max-width", "32rem")
                                 .style("margin", "10vh auto")

--- a/crates/tanoshi-web/src/settings_migrate.rs
+++ b/crates/tanoshi-web/src/settings_migrate.rs
@@ -116,8 +116,14 @@ impl SettingsMigrate {
 
             let mut map: BTreeMap<i64, Vec<Cover>> = BTreeMap::new();
             let mut seen: HashSet<i64> = HashSet::new();
-            for category_id in category_ids {
-                match query::fetch_manga_from_favorite(category_id).await {
+
+            let futures: Vec<_> = category_ids
+                .iter()
+                .map(|&category_id| query::fetch_manga_from_favorite(category_id))
+                .collect();
+            let results = futures::future::join_all(futures).await;
+            for result in results {
+                match result {
                     Ok(covers) => {
                         for c in covers {
                             if seen.insert(c.id) {

--- a/crates/tanoshi-web/src/settings_migrate.rs
+++ b/crates/tanoshi-web/src/settings_migrate.rs
@@ -1,0 +1,319 @@
+use std::{
+    collections::{BTreeMap, HashSet},
+    rc::Rc,
+};
+
+use dominator::{Dom, EventOptions, clone, events, html, routing};
+use futures_signals::{
+    signal::{Mutable, SignalExt},
+    signal_vec::MutableVec,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    common::{Cover, Route, Spinner, snackbar},
+    migration, query,
+    utils::AsyncLoader,
+};
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+struct SourceLite {
+    id: i64,
+    name: String,
+    icon: String,
+}
+
+pub struct SettingsMigrate {
+    loader: AsyncLoader,
+    spinner: Rc<Spinner>,
+
+    // source_id -> source meta
+    sources: MutableVec<SourceLite>,
+
+    // source_id -> covers
+    grouped: Mutable<BTreeMap<i64, Vec<Cover>>>,
+
+    // Which manga are we migrating
+    selected_cover: Mutable<Option<Cover>>,
+}
+
+impl SettingsMigrate {
+    pub fn new() -> Rc<Self> {
+        Rc::new(Self {
+            loader: AsyncLoader::new(),
+            spinner: Spinner::new(),
+            sources: MutableVec::new(),
+            grouped: Mutable::new(BTreeMap::new()),
+            selected_cover: Mutable::new(None),
+        })
+    }
+
+    fn open_picker(&self, cover: Cover) {
+        debug!("Selected cover {} for migration", cover.title);
+        self.selected_cover.set(Some(cover));
+    }
+
+    fn close_picker(&self) {
+        self.selected_cover.set(None);
+    }
+
+    fn go_to_destination(&self, dest_source_id: i64, cover: &Cover) {
+        debug!(
+            "Going to /catalogue/{} with migration context",
+            dest_source_id
+        );
+        // Save migration context so Catalogue knows we're selecting a target
+        migration::set(&migration::MigrationState {
+            from_manga_id: cover.id,
+            from_source_id: cover.source_id,
+            from_title: cover.title.clone(),
+            to_source_id: dest_source_id,
+        });
+
+        // Pre-fill catalogue search with the title
+        let url = Route::Catalogue {
+            id: dest_source_id,
+            latest: false,
+            query: Some(cover.title.clone()),
+        }
+        .url();
+
+        self.close_picker();
+
+        routing::go_to_url(&url);
+    }
+
+    pub fn fetch(settings: Rc<Self>) {
+        settings.spinner.set_active(true);
+
+        settings.loader.load(clone!(settings => async move {
+            // 1) Fetch sources (for names/icons)
+            match query::fetch_sources().await {
+                Ok(res) => {
+                    let sources: Vec<SourceLite> = res
+                        .iter()
+                        .map(|s| SourceLite {
+                            id: s.id,
+                            name: s.name.clone(),
+                            icon: s.icon.clone(),
+                        })
+                        .collect();
+
+                    settings.sources.lock_mut().replace_cloned(sources);
+                }
+                Err(e) => snackbar::show(format!("Failed to fetch sources: {e}")),
+            }
+
+            // 2) Fetch the full library and group by source_id. library(categoryId: null)
+            // only returns uncategorized manga, so every category has to be fetched too.
+            let mut category_ids: Vec<Option<i64>> = vec![None];
+            match query::fetch_categories().await {
+                Ok(categories) => {
+                    category_ids.extend(categories.iter().filter_map(|c| c.id).map(Some));
+                }
+                Err(e) => snackbar::show(format!("Failed to fetch categories: {e}")),
+            }
+
+            let mut map: BTreeMap<i64, Vec<Cover>> = BTreeMap::new();
+            let mut seen: HashSet<i64> = HashSet::new();
+            for category_id in category_ids {
+                match query::fetch_manga_from_favorite(category_id).await {
+                    Ok(covers) => {
+                        for c in covers {
+                            if seen.insert(c.id) {
+                                map.entry(c.source_id).or_default().push(c);
+                            }
+                        }
+                    }
+                    Err(e) => snackbar::show(format!("Failed to fetch library: {e}")),
+                }
+            }
+            for covers in map.values_mut() {
+                covers.sort_by(|a, b| a.title.cmp(&b.title));
+            }
+            settings.grouped.set(map);
+
+            settings.spinner.set_active(false);
+        }));
+    }
+
+    fn source_name(sources: &Vec<SourceLite>, source_id: i64) -> String {
+        sources
+            .iter()
+            .find(|s| s.id == source_id)
+            .map(|s| s.name.clone())
+            .unwrap_or_else(|| format!("Source {source_id}"))
+    }
+
+    pub fn render(self: Rc<Self>) -> Dom {
+        // load once on first render
+        if self.sources.lock_ref().is_empty() && self.grouped.get_cloned().is_empty() {
+            Self::fetch(self.clone());
+        }
+
+        html!("div", {
+            .class("content")
+            .style("padding", "0.5rem")
+            .children(&mut [
+                html!("div", {
+                    .style("margin-bottom", "0.5rem")
+                    .children(&mut [
+                        html!("h2", {.text("Migrate Manga")}),
+                        html!("div", {
+                            .style("font-size", "0.875rem")
+                            .style("opacity", "0.8")
+                            .text("Pick a manga from your library, then choose the destination source and manga. Categories, read progress, and trackers are carried over.")
+                        }),
+                    ])
+                }),
+                Spinner::render(self.spinner.clone()),
+            ])
+            .child_signal(self.grouped.signal_cloned().map({
+                let migrate = self.clone();
+                move |grouped| {
+                    let sources_vec = migrate.sources.lock_ref().to_vec();
+                    Some(html!("div", {
+                        .children(&mut grouped.into_iter().map(|(source_id, covers)| {
+                            let source_name = Self::source_name(&sources_vec, source_id);
+
+                            html!("div", {
+                                .style("margin-bottom", "1rem")
+                                .children(&mut [
+                                    html!("div", {
+                                        .style("display", "flex")
+                                        .style("justify-content", "space-between")
+                                        .style("align-items", "center")
+                                        .style("margin", "0.25rem 0")
+                                        .children(&mut [
+                                            html!("h3", { .text(&source_name) }),
+                                            html!("span", {
+                                                .style("font-size", "0.875rem")
+                                                .style("opacity", "0.8")
+                                                .text(format!("{}", covers.len()).as_str())
+                                            })
+                                        ])
+                                    }),
+                                    html!("ul", {
+                                        .class(["list", "group"])
+                                        .children(&mut covers.into_iter().map(|cover| {
+                                            html!("li", {
+                                                .class("list-item")
+                                                .style("display", "flex")
+                                                .style("justify-content", "space-between")
+                                                .style("align-items", "center")
+                                                .children(&mut [
+                                                    html!("span", {
+                                                        .style("overflow", "hidden")
+                                                        .style("text-overflow", "ellipsis")
+                                                        .style("white-space", "nowrap")
+                                                        .text(&cover.title)
+                                                    }),
+                                                    html!("button", {
+                                                        .text("Migrate")
+                                                        .event_with_options(&EventOptions::preventable(),
+                                                            clone!(migrate, cover => move |e: events::Click| {
+                                                                e.stop_propagation();
+                                                                migrate.open_picker(cover.clone());
+                                                            })
+                                                        )
+                                                    })
+                                                ])
+                                            })
+                                        }).collect::<Vec<_>>())
+                                    })
+                                ])
+                            })
+                        }).collect::<Vec<_>>())
+                    }))
+                }
+            }))
+            .child_signal(self.selected_cover.signal_cloned().map({
+                let migrate = self.clone();
+                move |selected| {
+                    selected.map(|cover| {
+                        // snapshot the sources list (cheap + avoids holding locks in closures)
+                        let sources = migrate.sources.lock_ref().to_vec();
+                        let current_source_id = cover.source_id;
+
+                        html!("div", {
+                            // Backdrop (visual only)
+                            .style("position", "fixed")
+                            .style("inset", "0")
+                            .style("background", "rgba(0,0,0,0.5)")
+                            .style("z-index", "9999")
+
+                            .child(html!("div", {
+                                // Modal card
+                                .style("background", "var(--bg, white)")
+                                .style("border-radius", "0.75rem")
+                                .style("max-width", "32rem")
+                                .style("margin", "10vh auto")
+                                .style("padding", "1rem")
+                                .children(&mut [
+                                    html!("h3", {
+                                        .style("margin", "0 0 0.25rem 0")
+                                        .text("Choose destination source")
+                                    }),
+                                    html!("div", {
+                                        .style("font-size", "0.9rem")
+                                        .style("opacity", "0.8")
+                                        .text(format!("Migrate: {}", cover.title).as_str())
+                                    }),
+                                    html!("div", { .style("height", "0.75rem") }),
+                                    html!("ul", {
+                                        .class(["list", "group"])
+                                        .children(&mut sources.into_iter()
+                                            .filter(|s| s.id != current_source_id)
+                                            .map(|s| {
+                                                html!("li", {
+                                                    .class("list-item")
+                                                    .style("display", "flex")
+                                                    .style("justify-content", "space-between")
+                                                    .style("align-items", "center")
+                                                    .children(&mut [
+                                                        html!("div", {
+                                                            .style("display", "flex")
+                                                            .style("align-items", "center")
+                                                            .children(&mut [
+                                                                html!("img", {
+                                                                    .style("width", "1.75rem")
+                                                                    .style("height", "1.75rem")
+                                                                    .style("margin-right", "0.5rem")
+                                                                    .attr("src", &s.icon)
+                                                                    .attr("alt", "")
+                                                                }),
+                                                                html!("span", { .text(&s.name) }),
+                                                            ])
+                                                        }),
+                                                        html!("button", {
+                                                            .text("Select")
+                                                            .event(clone!(migrate, cover => move |_: events::Click| {
+                                                                migrate.go_to_destination(s.id, &cover);
+                                                            }))
+                                                        })
+                                                    ])
+                                                })
+                                            })
+                                            .collect::<Vec<_>>()
+                                        )
+                                    }),
+                                    html!("div", {
+                                        .style("display", "flex")
+                                        .style("justify-content", "flex-end")
+                                        .style("margin-top", "0.75rem")
+                                        .child(html!("button", {
+                                            .text("Cancel")
+                                            .event(clone!(migrate => move |_: events::Click| {
+                                                migrate.close_picker();
+                                            }))
+                                        }))
+                                    })
+                                ])
+                            }))
+                        })
+                    })
+                }
+            }))
+        })
+    }
+}

--- a/crates/tanoshi/migrations/202607090000_sqlite.sql
+++ b/crates/tanoshi/migrations/202607090000_sqlite.sql
@@ -1,0 +1,4 @@
+CREATE INDEX idx_chapter_manga_id_number ON chapter(manga_id, number);
+-- COLLATE NOCASE matches the case-insensitive title comparison used when
+-- migrating read progress between sources.
+CREATE INDEX idx_chapter_manga_id_title ON chapter(manga_id, title COLLATE NOCASE);

--- a/crates/tanoshi/src/domain/repositories/library.rs
+++ b/crates/tanoshi/src/domain/repositories/library.rs
@@ -88,6 +88,13 @@ pub trait LibraryRepository: Clone + Send + Sync {
         manga_id: i64,
     ) -> Result<(), LibraryRepositoryError>;
 
+    async fn migrate_manga(
+        &self,
+        user_id: i64,
+        from_manga_id: i64,
+        to_manga_id: i64,
+    ) -> Result<(), LibraryRepositoryError>;
+
     async fn get_first_library_updates(
         &self,
         user_id: i64,

--- a/crates/tanoshi/src/domain/services/library.rs
+++ b/crates/tanoshi/src/domain/services/library.rs
@@ -115,6 +115,19 @@ where
         Ok(())
     }
 
+    pub async fn migrate_manga(
+        &self,
+        user_id: i64,
+        from_manga_id: i64,
+        to_manga_id: i64,
+    ) -> Result<(), LibraryError> {
+        self.repo
+            .migrate_manga(user_id, from_manga_id, to_manga_id)
+            .await?;
+
+        Ok(())
+    }
+
     pub async fn get_library_recent_updates(
         &self,
         user_id: i64,

--- a/crates/tanoshi/src/infrastructure/domain/repositories/library.rs
+++ b/crates/tanoshi/src/infrastructure/domain/repositories/library.rs
@@ -420,6 +420,117 @@ impl LibraryRepository for LibraryRepositoryImpl {
         Ok(())
     }
 
+    async fn migrate_manga(
+        &self,
+        user_id: i64,
+        from_manga_id: i64,
+        to_manga_id: i64,
+    ) -> Result<(), LibraryRepositoryError> {
+        let mut tx = self.pool.begin().await?;
+
+        // Move the library entry. Keeping the user_library row id carries its
+        // library_category rows along. OR IGNORE skips the move when the
+        // destination is already in the library (it keeps its own categories).
+        sqlx::query("UPDATE OR IGNORE user_library SET manga_id = ? WHERE user_id = ? AND manga_id = ?")
+            .bind(to_manga_id)
+            .bind(user_id)
+            .bind(from_manga_id)
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query("DELETE FROM user_library WHERE user_id = ? AND manga_id = ?")
+            .bind(user_id)
+            .bind(from_manga_id)
+            .execute(&mut *tx)
+            .await?;
+
+        // Copy read progress onto destination chapters matched by chapter
+        // number, preserving the original read_at. On conflict keep the
+        // furthest progress.
+        sqlx::query(
+            r#"
+        INSERT INTO user_history(user_id, chapter_id, last_page, read_at, is_complete)
+        SELECT uh.user_id, tc.id, uh.last_page, uh.read_at, uh.is_complete
+        FROM user_history uh
+            JOIN chapter fc
+                ON fc.id = uh.chapter_id
+                AND fc.manga_id = ?
+            JOIN chapter tc
+                ON tc.manga_id = ?
+                AND tc.number = fc.number
+        WHERE uh.user_id = ?
+        ON CONFLICT(user_id, chapter_id) DO UPDATE SET
+            last_page = MAX(user_history.last_page, excluded.last_page),
+            read_at = MAX(user_history.read_at, excluded.read_at),
+            is_complete = MAX(user_history.is_complete, excluded.is_complete)"#,
+        )
+        .bind(from_manga_id)
+        .bind(to_manga_id)
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await?;
+
+        // Fall back to title matching for chapters whose number has no
+        // counterpart in the destination.
+        sqlx::query(
+            r#"
+        INSERT INTO user_history(user_id, chapter_id, last_page, read_at, is_complete)
+        SELECT uh.user_id, tc.id, uh.last_page, uh.read_at, uh.is_complete
+        FROM user_history uh
+            JOIN chapter fc
+                ON fc.id = uh.chapter_id
+                AND fc.manga_id = ?
+            JOIN chapter tc
+                ON tc.manga_id = ?
+                AND tc.title = fc.title COLLATE NOCASE
+        WHERE uh.user_id = ?
+            AND NOT EXISTS (
+                SELECT 1 FROM chapter t2 WHERE t2.manga_id = tc.manga_id AND t2.number = fc.number
+            )
+        ON CONFLICT(user_id, chapter_id) DO UPDATE SET
+            last_page = MAX(user_history.last_page, excluded.last_page),
+            read_at = MAX(user_history.read_at, excluded.read_at),
+            is_complete = MAX(user_history.is_complete, excluded.is_complete)"#,
+        )
+        .bind(from_manga_id)
+        .bind(to_manga_id)
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await?;
+
+        // Remove the old history so the migrated manga doesn't show up twice
+        // in reading history.
+        sqlx::query(
+            r#"
+        DELETE FROM user_history
+        WHERE user_id = ?
+            AND chapter_id IN (SELECT id FROM chapter WHERE manga_id = ?)"#,
+        )
+        .bind(user_id)
+        .bind(from_manga_id)
+        .execute(&mut *tx)
+        .await?;
+
+        // Move trackers. OR IGNORE skips trackers already attached to the
+        // destination; leftovers on the old manga are removed after.
+        sqlx::query("UPDATE OR IGNORE tracker_manga SET manga_id = ? WHERE user_id = ? AND manga_id = ?")
+            .bind(to_manga_id)
+            .bind(user_id)
+            .bind(from_manga_id)
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query("DELETE FROM tracker_manga WHERE user_id = ? AND manga_id = ?")
+            .bind(user_id)
+            .bind(from_manga_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+
+        Ok(())
+    }
+
     async fn get_first_library_updates(
         &self,
         user_id: i64,

--- a/crates/tanoshi/src/infrastructure/domain/repositories/library.rs
+++ b/crates/tanoshi/src/infrastructure/domain/repositories/library.rs
@@ -445,56 +445,75 @@ impl LibraryRepository for LibraryRepositoryImpl {
             .await?;
 
         // Copy read progress onto destination chapters matched by chapter
-        // number, preserving the original read_at. On conflict keep the
+        // number, preserving the original read_at. The scalar subquery
+        // (ORDER BY id LIMIT 1) picks exactly one destination chapter even
+        // when the destination has duplicate chapter numbers; unmatched
+        // chapters resolve to NULL and are filtered out. On conflict keep the
         // furthest progress.
         sqlx::query(
             r#"
         INSERT INTO user_history(user_id, chapter_id, last_page, read_at, is_complete)
-        SELECT uh.user_id, tc.id, uh.last_page, uh.read_at, uh.is_complete
-        FROM user_history uh
-            JOIN chapter fc
-                ON fc.id = uh.chapter_id
-                AND fc.manga_id = ?
-            JOIN chapter tc
-                ON tc.manga_id = ?
-                AND tc.number = fc.number
-        WHERE uh.user_id = ?
+        SELECT user_id, to_chapter_id, last_page, read_at, is_complete
+        FROM (
+            SELECT uh.user_id AS user_id,
+                   (SELECT tc.id FROM chapter tc
+                    WHERE tc.manga_id = ? AND tc.number = fc.number
+                    ORDER BY tc.id LIMIT 1) AS to_chapter_id,
+                   uh.last_page AS last_page,
+                   uh.read_at AS read_at,
+                   uh.is_complete AS is_complete
+            FROM user_history uh
+                JOIN chapter fc
+                    ON fc.id = uh.chapter_id
+                    AND fc.manga_id = ?
+            WHERE uh.user_id = ?
+        )
+        WHERE to_chapter_id IS NOT NULL
         ON CONFLICT(user_id, chapter_id) DO UPDATE SET
             last_page = MAX(user_history.last_page, excluded.last_page),
             read_at = MAX(user_history.read_at, excluded.read_at),
             is_complete = MAX(user_history.is_complete, excluded.is_complete)"#,
         )
-        .bind(from_manga_id)
         .bind(to_manga_id)
+        .bind(from_manga_id)
         .bind(user_id)
         .execute(&mut *tx)
         .await?;
 
         // Fall back to title matching for chapters whose number has no
-        // counterpart in the destination.
+        // counterpart in the destination. Same single-match + NULL-filter
+        // scheme as above.
         sqlx::query(
             r#"
         INSERT INTO user_history(user_id, chapter_id, last_page, read_at, is_complete)
-        SELECT uh.user_id, tc.id, uh.last_page, uh.read_at, uh.is_complete
-        FROM user_history uh
-            JOIN chapter fc
-                ON fc.id = uh.chapter_id
-                AND fc.manga_id = ?
-            JOIN chapter tc
-                ON tc.manga_id = ?
-                AND tc.title = fc.title COLLATE NOCASE
-        WHERE uh.user_id = ?
-            AND NOT EXISTS (
-                SELECT 1 FROM chapter t2 WHERE t2.manga_id = tc.manga_id AND t2.number = fc.number
-            )
+        SELECT user_id, to_chapter_id, last_page, read_at, is_complete
+        FROM (
+            SELECT uh.user_id AS user_id,
+                   (SELECT tc.id FROM chapter tc
+                    WHERE tc.manga_id = ? AND tc.title = fc.title COLLATE NOCASE
+                    ORDER BY tc.id LIMIT 1) AS to_chapter_id,
+                   uh.last_page AS last_page,
+                   uh.read_at AS read_at,
+                   uh.is_complete AS is_complete
+            FROM user_history uh
+                JOIN chapter fc
+                    ON fc.id = uh.chapter_id
+                    AND fc.manga_id = ?
+            WHERE uh.user_id = ?
+                AND NOT EXISTS (
+                    SELECT 1 FROM chapter t2 WHERE t2.manga_id = ? AND t2.number = fc.number
+                )
+        )
+        WHERE to_chapter_id IS NOT NULL
         ON CONFLICT(user_id, chapter_id) DO UPDATE SET
             last_page = MAX(user_history.last_page, excluded.last_page),
             read_at = MAX(user_history.read_at, excluded.read_at),
             is_complete = MAX(user_history.is_complete, excluded.is_complete)"#,
         )
-        .bind(from_manga_id)
         .bind(to_manga_id)
+        .bind(from_manga_id)
         .bind(user_id)
+        .bind(to_manga_id)
         .execute(&mut *tx)
         .await?;
 

--- a/crates/tanoshi/src/presentation/graphql/library.rs
+++ b/crates/tanoshi/src/presentation/graphql/library.rs
@@ -9,13 +9,14 @@ use crate::{
     },
     domain::services::{
         chapter::ChapterService, history::HistoryService, library::LibraryService,
-        tracker::TrackerService,
+        manga::MangaService, tracker::TrackerService,
     },
     infrastructure::{
         auth::Claims,
         domain::repositories::{
             chapter::ChapterRepositoryImpl, history::HistoryRepositoryImpl,
-            library::LibraryRepositoryImpl, tracker::TrackerRepositoryImpl,
+            library::LibraryRepositoryImpl, manga::MangaRepositoryImpl,
+            tracker::TrackerRepositoryImpl,
         },
     },
 };
@@ -236,6 +237,44 @@ impl LibraryMutationRoot {
             .await?;
 
         Ok(1)
+    }
+
+    /// Migrate a manga to another source: moves the library entry with its
+    /// categories, read progress and trackers to the manga at `to_path` on
+    /// `to_source_id`. Returns the destination manga id.
+    async fn migrate_manga(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(desc = "manga id to migrate from")] manga_id: i64,
+        #[graphql(desc = "destination source id")] to_source_id: i64,
+        #[graphql(desc = "destination manga path")] to_path: String,
+    ) -> Result<i64> {
+        let claims = ctx
+            .data::<Claims>()
+            .map_err(|_| "token not exists, please login")?;
+
+        // Resolve the destination manga; this stores it if it was only seen
+        // through browsing so far.
+        let to_manga = ctx
+            .data::<MangaService<MangaRepositoryImpl>>()?
+            .fetch_manga_by_source_path(to_source_id, &to_path)
+            .await?;
+
+        if to_manga.id == manga_id {
+            return Err("cannot migrate a manga to itself".into());
+        }
+
+        // Make sure the destination chapters exist so read progress has
+        // something to map onto.
+        ctx.data::<ChapterService<ChapterRepositoryImpl>>()?
+            .fetch_chapters_by_manga_id(to_source_id, &to_manga.path, to_manga.id, true)
+            .await?;
+
+        ctx.data::<LibraryService<LibraryRepositoryImpl>>()?
+            .migrate_manga(claims.sub, manga_id, to_manga.id)
+            .await?;
+
+        Ok(to_manga.id)
     }
 
     async fn update_page_read_at(


### PR DESCRIPTION
Add a mutation to migrate a library manga to a different source, moving categories, read progress, and trackers in one transaction.  Include a UI in the settings page that lets users pick a library manga and a destination source, then pre-fills the catalogue search so they can select the target manga.  Add the `MigrateManga` query to `tanoshi-schema` and a `urlencoding` dependency for the frontend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manga migration support to move a library entry to another source/title while preserving reading progress and related data.
  * Introduced a “Migrate Manga” settings page and a migration flow in the catalogue with a destination picker, confirmation modal, and success/failure feedback.
* **Bug Fixes**
  * Improved catalogue routing and query handling (better `query` vs `keyword` behavior and cleaner URL generation).
* **Chores**
  * Improved migration performance with additional database indexes for chapter lookups during progress transfer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->