### PR TITLE
Make update scans source-aware parallelization and resilient

### DIFF
--- a/crates/tanoshi-vm/src/extension/manager.rs
+++ b/crates/tanoshi-vm/src/extension/manager.rs
@@ -219,6 +219,46 @@ struct ExtensionCall {
     quarantine_on_panic: bool,
 }
 
+#[derive(Debug)]
+pub enum ExtensionError {
+    MissingSource,
+    Operational {
+        kind: &'static str,
+        message: String,
+    },
+}
+
+impl ExtensionError {
+    fn operational(kind: &'static str, message: impl Into<String>) -> Self {
+        Self::Operational {
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for ExtensionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingSource => formatter.write_str("no such source"),
+            Self::Operational { kind, message } => write!(formatter, "[{kind}] {message}"),
+        }
+    }
+}
+
+impl std::error::Error for ExtensionError {}
+
+fn missing_source_error() -> anyhow::Error {
+    anyhow::Error::new(ExtensionError::MissingSource)
+}
+
+fn operational_extension_error(
+    kind: &'static str,
+    message: impl Into<String>,
+) -> anyhow::Error {
+    anyhow::Error::new(ExtensionError::operational(kind, message))
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct ExtensionManagerOptions {
     pub max_concurrent_calls: usize,
@@ -424,7 +464,7 @@ impl ExtensionManager {
         self.read()?
             .get(&source_id)
             .cloned()
-            .ok_or_else(|| anyhow!("no such source"))
+            .ok_or_else(missing_source_error)
     }
 
     async fn acquire_permit(
@@ -449,19 +489,25 @@ impl ExtensionManager {
                 error!(
                     "EXTENSION ADMISSION ERROR: source_id={source_id} source={source_name:?} operation={operation} limiter unavailable: {error}"
                 );
-                bail!(
-                    "[extension-admission] source {source_id} ({source_name}) cannot accept {operation}: {error}"
-                );
+                Err(operational_extension_error(
+                    "extension-admission",
+                    format!(
+                        "source {source_id} ({source_name}) cannot accept {operation}: {error}"
+                    ),
+                ))
             }
             Err(_) => {
                 error!(
                     "EXTENSION SATURATION: source_id={source_id} source={source_name:?} operation={operation} exceeded the {}-call limit; request rejected after {:?}",
                     self.options.max_concurrent_calls, self.options.admission_timeout
                 );
-                bail!(
-                    "[extension-saturated] source {source_id} ({source_name}) is busy; {operation} admission timed out after {:?}",
-                    self.options.admission_timeout
-                );
+                Err(operational_extension_error(
+                    "extension-saturated",
+                    format!(
+                        "source {source_id} ({source_name}) is busy; {operation} admission timed out after {:?}",
+                        self.options.admission_timeout
+                    ),
+                ))
             }
         }
     }
@@ -479,17 +525,23 @@ impl ExtensionManager {
                 error!(
                     "EXTENSION CIRCUIT OPEN: source_id={source_id} source={source_name:?} operation={operation} has {abandoned_calls} timed-out native calls still running; rejecting new work"
                 );
-                bail!(
-                    "[extension-circuit-open] source {source_id} ({source_name}) has {abandoned_calls} timed-out native calls still running; replace or restart the source before retrying {operation}"
-                );
+                Err(operational_extension_error(
+                    "extension-circuit-open",
+                    format!(
+                        "source {source_id} ({source_name}) has {abandoned_calls} timed-out native calls still running; replace or restart the source before retrying {operation}"
+                    ),
+                ))
             }
             SourceAdmission::Quarantined => {
                 error!(
                     "EXTENSION QUARANTINED: source_id={source_id} source={source_name:?} operation={operation}; rejecting new work until replacement or reload"
                 );
-                bail!(
-                    "[extension-quarantined] source {source_id} ({source_name}) is quarantined; replace or reload the extension before retrying {operation}"
-                );
+                Err(operational_extension_error(
+                    "extension-quarantined",
+                    format!(
+                        "source {source_id} ({source_name}) is quarantined; replace or reload the extension before retrying {operation}"
+                    ),
+                ))
             }
         }
     }
@@ -603,8 +655,11 @@ impl ExtensionManager {
                             "EXTENSION QUARANTINED: source_id={source_id} source={task_source_name:?} operation={operation}; replace or reload the extension before retrying"
                         );
                     }
-                    Err(anyhow!(
-                        "[extension-panicked] source {source_id} ({task_source_name}) {operation} panicked: {message}"
+                    Err(operational_extension_error(
+                        "extension-panicked",
+                        format!(
+                            "source {source_id} ({task_source_name}) {operation} panicked: {message}"
+                        ),
                     ))
                 }
             };
@@ -633,9 +688,12 @@ impl ExtensionManager {
                             "EXTENSION QUARANTINED: source_id={source_id} source={source_name:?} operation={operation}; replace or reload the extension before retrying"
                         );
                     }
-                    bail!(
-                        "[extension-panicked] source {source_id} ({source_name}) {operation} panicked"
-                    );
+                    return Err(operational_extension_error(
+                        "extension-panicked",
+                        format!(
+                            "source {source_id} ({source_name}) {operation} panicked"
+                        ),
+                    ));
                 }
                 bail!(
                     "[extension-cancelled] source {source_id} ({source_name}) {operation} task was cancelled"
@@ -657,9 +715,12 @@ impl ExtensionManager {
                 error!(
                     "EXTENSION TIMEOUT: source_id={source_id} source={source_name:?} operation={operation} exceeded {timeout:?}; native call may still be running and its permit remains held"
                 );
-                bail!(
-                    "[extension-timeout] source {source_id} ({source_name}) {operation} exceeded {timeout:?}; native call may still be running"
-                );
+                return Err(operational_extension_error(
+                    "extension-timeout",
+                    format!(
+                        "source {source_id} ({source_name}) {operation} exceeded {timeout:?}; native call may still be running"
+                    ),
+                ));
             }
         }
     }
@@ -710,13 +771,19 @@ impl ExtensionManager {
                 error!(
                     "EXTENSION WORKER SUPERVISOR PANIC: source_id={source_id} source={source_name:?} operation={operation}"
                 );
-                bail!(
-                    "[extension-worker-supervisor] source {source_id} ({source_name}) {operation} supervisor panicked"
-                );
+                Err(operational_extension_error(
+                    "extension-worker-supervisor",
+                    format!(
+                        "source {source_id} ({source_name}) {operation} supervisor panicked"
+                    ),
+                ))
             }
-            Err(error) => bail!(
-                "[extension-worker-supervisor] source {source_id} ({source_name}) {operation} supervisor was cancelled: {error}"
-            ),
+            Err(error) => Err(operational_extension_error(
+                "extension-worker-supervisor",
+                format!(
+                    "source {source_id} ({source_name}) {operation} supervisor was cancelled: {error}"
+                ),
+            )),
         }
     }
 
@@ -749,8 +816,11 @@ impl ExtensionManager {
                     error!(
                         "EXTENSION WORKER PROTOCOL ERROR: source_id={source_id} source={source_name:?} operation={operation} response={error}"
                     );
-                    anyhow!(
-                        "[extension-worker-protocol] source {source_id} ({source_name}) {operation} returned an invalid response: {error}"
+                    operational_extension_error(
+                        "extension-worker-protocol",
+                        format!(
+                            "source {source_id} ({source_name}) {operation} returned an invalid response: {error}"
+                        ),
                     )
                 })?;
                 health.record_success();
@@ -768,8 +838,11 @@ impl ExtensionManager {
                 warn!(
                     "EXTENSION WORKER BUSY: source_id={source_id} source={source_name:?} operation={operation} spent {timeout:?} waiting behind earlier calls; the worker was not disturbed"
                 );
-                Err(anyhow!(
-                    "[extension-worker-busy] source {source_id} ({source_name}) is busy; {operation} timed out after {timeout:?} waiting for earlier calls"
+                Err(operational_extension_error(
+                    "extension-worker-busy",
+                    format!(
+                        "source {source_id} ({source_name}) is busy; {operation} timed out after {timeout:?} waiting for earlier calls"
+                    ),
                 ))
             }
             // The source was unloaded or replaced mid-call; the retired
@@ -818,9 +891,12 @@ impl ExtensionManager {
                 } else {
                     "extension-worker-crashed"
                 };
-                bail!(
-                    "[{error_kind}] source {source_id} ({source_name}) {operation} failed: {message}"
-                );
+                Err(operational_extension_error(
+                    error_kind,
+                    format!(
+                        "source {source_id} ({source_name}) {operation} failed: {message}"
+                    ),
+                ))
             }
         }
     }
@@ -1212,7 +1288,7 @@ impl ExtensionManager {
         let sources = self.read()?;
         let source = sources
             .get(&source_id)
-            .ok_or_else(|| anyhow!("no such source"))?;
+            .ok_or_else(missing_source_error)?;
         let rustc_version = source.rustc_version.clone();
         let lib_version = source.lib_version.clone();
         Ok((rustc_version, lib_version))
@@ -1287,7 +1363,7 @@ impl ExtensionManager {
         let _lifecycle_guard = lifecycle_lock.lock_owned().await;
         let entry = self
             .entry_for_plugin(&plugin_name)?
-            .ok_or_else(|| anyhow!("no such source"))?;
+            .ok_or_else(missing_source_error)?;
         let source_name = entry.source_info.name.to_lowercase();
         let extension_preferences = preferences.clone();
         self.call_blocking_mut_entry(

--- a/crates/tanoshi/src/application/bootstrap.rs
+++ b/crates/tanoshi/src/application/bootstrap.rs
@@ -176,6 +176,7 @@ pub async fn bootstrap(config: Config) -> Result<App> {
     let (chapter_update_receiver, chapter_update_command_tx, update_worker_handle) =
         worker::updates::start(
             config.update_interval,
+            config.max_concurrent_update_sources,
             library_repo.clone(),
             manga_repo.clone(),
             chapter_repo.clone(),

--- a/crates/tanoshi/src/application/worker/updates.rs
+++ b/crates/tanoshi/src/application/worker/updates.rs
@@ -234,20 +234,18 @@ where
 
     async fn start_chapter_update_queue_by_manga_id(
         &self,
-        tx: tokio::sync::mpsc::Sender<Manga>,
+        tx: &tokio::sync::mpsc::Sender<Manga>,
         manga_id: i64,
-    ) {
-        let manga = self.manga_repo.get_manga_by_id(manga_id).await;
-        match manga {
-            Ok(manga) => {
-                if let Err(e) = tx.send(manga).await {
-                    error!("error sending manga {} to update channel: {e:?}", manga_id);
-                }
-            }
-            Err(e) => {
-                error!("error getting manga {manga_id} for update: {e:?}");
-            }
-        }
+    ) -> Result<(), anyhow::Error> {
+        let manga = self
+            .manga_repo
+            .get_manga_by_id(manga_id)
+            .await
+            .map_err(|error| anyhow::anyhow!("failed to get manga {manga_id} for update: {error}"))?;
+        tx.send(manga)
+            .await
+            .map_err(|error| anyhow::anyhow!("failed to queue manga {manga_id} for update: {error}"))?;
+        Ok(())
     }
 
     fn start_chapter_update_queue_by_user_id(
@@ -317,6 +315,13 @@ where
 
         if let Some(error) = first_error {
             return Err(error);
+        }
+
+        if run_summary.failed > 0 || run_summary.skipped > 0 {
+            return Err(anyhow::anyhow!(
+                "update run {run_kind} completed with {} failed and {} skipped manga",
+                run_summary.failed, run_summary.skipped
+            ));
         }
 
         Ok(())
@@ -595,9 +600,17 @@ where
                             }
                         },
                         ChapterUpdateCommand::Manga(manga_id, tx) => {
-                            self.start_chapter_update_queue_by_manga_id(manga_tx, manga_id).await;
-                            let run_kind = format!("manual-manga:{manga_id}");
-                            let res = self.check_chapter_update(manga_rx, &run_kind).await;
+                            let queue_result = self
+                                .start_chapter_update_queue_by_manga_id(&manga_tx, manga_id)
+                                .await;
+                            drop(manga_tx);
+                            let res = match queue_result {
+                                Ok(()) => {
+                                    let run_kind = format!("manual-manga:{manga_id}");
+                                    self.check_chapter_update(manga_rx, &run_kind).await
+                                }
+                                Err(error) => Err(error),
+                            };
                             if tx.send(res).is_err() {
                                 debug!("chapter update result receiver dropped (Manga {manga_id})");
                             }

--- a/crates/tanoshi/src/application/worker/updates.rs
+++ b/crates/tanoshi/src/application/worker/updates.rs
@@ -97,6 +97,7 @@ where
     L: LibraryRepository + 'static,
 {
     period: u64,
+    max_concurrent_sources: usize,
     client: reqwest::Client,
     library_repo: L,
     manga_repo: M,
@@ -118,6 +119,7 @@ where
     #[allow(clippy::too_many_arguments)]
     fn new<P: AsRef<Path>>(
         period: u64,
+        max_concurrent_sources: usize,
         library_repo: L,
         manga_repo: M,
         chapter_repo: C,
@@ -134,12 +136,15 @@ where
             period
         };
         info!("periodic updates every {period} seconds");
+        let max_concurrent_sources = max_concurrent_sources.max(1);
+        info!("updating up to {max_concurrent_sources} sources concurrently");
 
         let (command_tx, command_rx) = flume::bounded(0);
 
         (
             Self {
                 period,
+                max_concurrent_sources,
                 client: reqwest::Client::new(),
                 library_repo,
                 manga_repo,
@@ -198,96 +203,134 @@ where
         &self,
         mut rx: tokio::sync::mpsc::Receiver<Manga>,
     ) -> Result<(), anyhow::Error> {
+        let mut mangas_by_source: HashMap<i64, Vec<Manga>> = HashMap::new();
         while let Some(manga) = rx.recv().await {
-            debug!("Checking updates: {}", manga.title);
+            mangas_by_source
+                .entry(manga.source_id)
+                .or_default()
+                .push(manga);
+        }
 
-            let chapters: Vec<Chapter> = match self
-                .extensions
-                .get_chapters(manga.source_id, manga.path.clone())
-                .await
-            {
-                Ok(chapters) => chapters
-                    .into_par_iter()
-                    .map(|ch| {
-                        let mut c: Chapter = ch.into();
-                        c.manga_id = manga.id;
-                        c
-                    })
-                    .collect(),
-                Err(e) => {
-                    error!("error fetch new chapters for {}, source {}, reason: {e}", manga.title, manga.source_id);
-                    continue;
-                }
-            };
+        let mut source_updates = futures::stream::iter(mangas_by_source)
+            .map(|(source_id, mangas)| async move {
+                let result = self.check_source_updates(mangas).await;
+                (source_id, result)
+            })
+            .buffer_unordered(self.max_concurrent_sources);
+        let mut first_error = None;
 
-            self.chapter_repo.insert_chapters(&chapters).await?;
-
-            let chapter_paths: Vec<String> = chapters.into_par_iter().map(|c| c.path).collect();
-
-            if !chapter_paths.is_empty() {
-                let chapters_to_delete: Vec<i64> = self
-                    .chapter_repo
-                    .get_chapters_not_in_source(manga.source_id, manga.id, &chapter_paths)
-                    .await?
-                    .iter()
-                    .map(|c| c.id)
-                    .collect();
-
-                if !chapters_to_delete.is_empty() {
-                    self.chapter_repo
-                        .delete_chapter_by_ids(&chapters_to_delete)
-                        .await?;
+        while let Some((source_id, result)) = source_updates.next().await {
+            if let Err(error) = result {
+                error!("update scan stopped for source {source_id}: {error}");
+                if first_error.is_none() {
+                    first_error = Some(error);
                 }
             }
+        }
 
-            let last_uploaded_chapter = manga.last_uploaded_at.unwrap_or_default();
+        if let Some(error) = first_error {
+            return Err(error);
+        }
 
-            let chapters: Vec<Chapter> = self
-                .chapter_repo
-                .get_chapters_by_manga_id(manga.id, None, None, false)
-                .await?
+        Ok(())
+    }
+
+    async fn check_source_updates(&self, mangas: Vec<Manga>) -> Result<(), anyhow::Error> {
+        for manga in mangas {
+            self.check_manga_update(manga).await?;
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+
+        Ok(())
+    }
+
+    async fn check_manga_update(&self, manga: Manga) -> Result<(), anyhow::Error> {
+        debug!("Checking updates: {}", manga.title);
+
+        let chapters: Vec<Chapter> = match self
+            .extensions
+            .get_chapters(manga.source_id, manga.path.clone())
+            .await
+        {
+            Ok(chapters) => chapters
                 .into_par_iter()
-                .filter(|chapter| chapter.uploaded > last_uploaded_chapter)
+                .map(|ch| {
+                    let mut c: Chapter = ch.into();
+                    c.manga_id = manga.id;
+                    c
+                })
+                .collect(),
+            Err(e) => {
+                error!("error fetch new chapters for {}, source {}, reason: {e}", manga.title, manga.source_id);
+                return Ok(());
+            }
+        };
+
+        self.chapter_repo.insert_chapters(&chapters).await?;
+
+        let chapter_paths: Vec<String> = chapters.into_par_iter().map(|c| c.path).collect();
+
+        if !chapter_paths.is_empty() {
+            let chapters_to_delete: Vec<i64> = self
+                .chapter_repo
+                .get_chapters_not_in_source(manga.source_id, manga.id, &chapter_paths)
+                .await?
+                .iter()
+                .map(|c| c.id)
                 .collect();
 
-            if chapters.is_empty() {
-                debug!("{} has no new chapters", manga.title);
-            } else {
-                info!("{} has {} new chapters", manga.title, chapters.len());
+            if !chapters_to_delete.is_empty() {
+                self.chapter_repo
+                    .delete_chapter_by_ids(&chapters_to_delete)
+                    .await?;
+            }
+        }
+
+        let last_uploaded_chapter = manga.last_uploaded_at.unwrap_or_default();
+
+        let chapters: Vec<Chapter> = self
+            .chapter_repo
+            .get_chapters_by_manga_id(manga.id, None, None, false)
+            .await?
+            .into_par_iter()
+            .filter(|chapter| chapter.uploaded > last_uploaded_chapter)
+            .collect();
+
+        if chapters.is_empty() {
+            debug!("{} has no new chapters", manga.title);
+        } else {
+            info!("{} has {} new chapters", manga.title, chapters.len());
+        }
+
+        let users = self
+            .library_repo
+            .get_users_by_manga_id(manga.id)
+            .await
+            .unwrap_or_default();
+
+        for chapter in chapters {
+            for user in &users {
+                self.notifier
+                    .send_chapter_notification(
+                        user.id,
+                        &manga.title,
+                        &chapter.title,
+                        chapter.id,
+                    )
+                    .await?;
             }
 
-            let users = self
-                .library_repo
-                .get_users_by_manga_id(manga.id)
-                .await
-                .unwrap_or_default();
-
-            for chapter in chapters {
-                for user in &users {
-                    self.notifier
-                        .send_chapter_notification(
-                            user.id,
-                            &manga.title,
-                            &chapter.title,
-                            chapter.id,
-                        )
-                        .await?;
-                }
-
-                if let Err(e) = self.broadcast_tx.send(ChapterUpdate {
-                    manga: manga.clone(),
-                    chapter,
-                    users: users.iter().map(|user| user.id).collect(),
-                }) {
-                    // the send error hands the unsent update back
-                    error!(
-                        "error broadcasting new chapter '{}' for manga '{}': {e}",
-                        e.0.chapter.title, manga.title
-                    );
-                }
+            if let Err(e) = self.broadcast_tx.send(ChapterUpdate {
+                manga: manga.clone(),
+                chapter,
+                users: users.iter().map(|user| user.id).collect(),
+            }) {
+                // the send error hands the unsent update back
+                error!(
+                    "error broadcasting new chapter '{}' for manga '{}': {e}",
+                    e.0.chapter.title, manga.title
+                );
             }
-
-            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         }
 
         Ok(())
@@ -470,6 +513,7 @@ where
 #[allow(clippy::too_many_arguments)]
 pub fn start<C, M, L, P>(
     period: u64,
+    max_concurrent_sources: usize,
     library_repo: L,
     manga_repo: M,
     chapter_repo: C,
@@ -491,6 +535,7 @@ where
     let (broadcast_tx, broadcast_rx) = tokio::sync::broadcast::channel(10);
     let (worker, command_tx) = UpdatesWorker::new(
         period,
+        max_concurrent_sources,
         library_repo,
         manga_repo,
         chapter_repo,

--- a/crates/tanoshi/src/application/worker/updates.rs
+++ b/crates/tanoshi/src/application/worker/updates.rs
@@ -3,6 +3,7 @@ use std::{
     fmt::Display,
     path::{Path, PathBuf},
     str::FromStr,
+    time::Duration,
 };
 
 use futures::StreamExt;
@@ -29,6 +30,8 @@ use tokio::{
 };
 
 const SOURCE_UPDATE_FAILURE_THRESHOLD: usize = 3;
+const UPDATE_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const UPDATE_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Copy)]
 enum MangaUpdateOutcome {
@@ -181,6 +184,11 @@ where
         info!("periodic updates every {period} seconds");
         let max_concurrent_sources = max_concurrent_sources.max(1);
         info!("updating up to {max_concurrent_sources} sources concurrently");
+        let client = reqwest::Client::builder()
+            .connect_timeout(UPDATE_HTTP_CONNECT_TIMEOUT)
+            .timeout(UPDATE_HTTP_TIMEOUT)
+            .build()
+            .expect("failed to build update worker HTTP client");
 
         let (command_tx, command_rx) = flume::bounded(0);
 
@@ -188,7 +196,7 @@ where
             Self {
                 period,
                 max_concurrent_sources,
-                client: reqwest::Client::new(),
+                client,
                 library_repo,
                 manga_repo,
                 chapter_repo,

--- a/crates/tanoshi/src/application/worker/updates.rs
+++ b/crates/tanoshi/src/application/worker/updates.rs
@@ -11,13 +11,13 @@ use rayon::prelude::*;
 use serde::Deserialize;
 
 use tanoshi_lib::prelude::Version;
-use tanoshi_vm::extension::ExtensionManager;
+use tanoshi_vm::extension::{ExtensionError, ExtensionManager};
 
 use crate::{
     domain::{
         entities::{chapter::Chapter, manga::Manga},
         repositories::{
-            chapter::ChapterRepository,
+            chapter::{ChapterRepository, ChapterRepositoryError},
             library::{LibraryRepository, LibraryRepositoryError},
             manga::MangaRepository,
         },
@@ -54,27 +54,9 @@ struct SourceUpdateResult {
 }
 
 fn is_operational_source_failure(error: &anyhow::Error) -> bool {
-    const OPERATIONAL_ERROR_PREFIXES: &[&str] = &[
-        "[extension-admission]",
-        "[extension-circuit-open]",
-        "[extension-panicked]",
-        "[extension-quarantined]",
-        "[extension-saturated]",
-        "[extension-timeout]",
-        "[extension-worker-busy]",
-        "[extension-worker-crashed]",
-        "[extension-worker-protocol]",
-        "[extension-worker-supervisor]",
-        "[extension-worker-timeout]",
-    ];
-
-    let message = error.to_string();
-    OPERATIONAL_ERROR_PREFIXES
-        .iter()
-        .any(|prefix| message.starts_with(prefix))
-        || error
-            .chain()
-            .any(|cause| cause.to_string() == "no such source")
+    error
+        .chain()
+        .any(|cause| cause.downcast_ref::<ExtensionError>().is_some())
         || error.chain().any(|cause| {
             cause
                 .downcast_ref::<reqwest::Error>()
@@ -85,6 +67,25 @@ fn is_operational_source_failure(error: &anyhow::Error) -> bool {
                         || error.is_timeout()
                 })
         })
+}
+
+fn handle_chapter_repository_error(
+    manga: &Manga,
+    operation: &'static str,
+    error: ChapterRepositoryError,
+) -> Result<MangaUpdateOutcome, anyhow::Error> {
+    error!(
+        "error {operation} for {}, source {}, reason: {error}",
+        manga.title, manga.source_id
+    );
+    if matches!(&error, ChapterRepositoryError::DbError(_)) {
+        Err(anyhow::anyhow!(
+            "chapter repository {operation} failed for manga {}: {error}",
+            manga.id
+        ))
+    } else {
+        Ok(MangaUpdateOutcome::ItemFailure)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -407,32 +408,64 @@ where
             }
         };
 
-        self.chapter_repo.insert_chapters(&chapters).await?;
+        if let Err(error) = self.chapter_repo.insert_chapters(&chapters).await {
+            return handle_chapter_repository_error(&manga, "insert_chapters", error);
+        }
 
         let chapter_paths: Vec<String> = chapters.into_par_iter().map(|c| c.path).collect();
 
         if !chapter_paths.is_empty() {
-            let chapters_to_delete: Vec<i64> = self
+            let chapters_not_in_source = match self
                 .chapter_repo
                 .get_chapters_not_in_source(manga.source_id, manga.id, &chapter_paths)
-                .await?
+                .await
+            {
+                Ok(chapters) => chapters,
+                Err(error) => {
+                    return handle_chapter_repository_error(
+                        &manga,
+                        "get_chapters_not_in_source",
+                        error,
+                    );
+                }
+            };
+            let chapters_to_delete: Vec<i64> = chapters_not_in_source
                 .iter()
                 .map(|c| c.id)
                 .collect();
 
             if !chapters_to_delete.is_empty() {
-                self.chapter_repo
+                if let Err(error) = self
+                    .chapter_repo
                     .delete_chapter_by_ids(&chapters_to_delete)
-                    .await?;
+                    .await
+                {
+                    return handle_chapter_repository_error(
+                        &manga,
+                        "delete_chapter_by_ids",
+                        error,
+                    );
+                }
             }
         }
 
         let last_uploaded_chapter = manga.last_uploaded_at.unwrap_or_default();
 
-        let chapters: Vec<Chapter> = self
+        let chapters = match self
             .chapter_repo
             .get_chapters_by_manga_id(manga.id, None, None, false)
-            .await?
+            .await
+        {
+            Ok(chapters) => chapters,
+            Err(error) => {
+                return handle_chapter_repository_error(
+                    &manga,
+                    "get_chapters_by_manga_id",
+                    error,
+                );
+            }
+        };
+        let chapters: Vec<Chapter> = chapters
             .into_par_iter()
             .filter(|chapter| chapter.uploaded > last_uploaded_chapter)
             .collect();

--- a/crates/tanoshi/src/application/worker/updates.rs
+++ b/crates/tanoshi/src/application/worker/updates.rs
@@ -40,6 +40,19 @@ enum MangaUpdateOutcome {
     SourceFailure,
 }
 
+#[derive(Debug, Default)]
+struct SourceUpdateSummary {
+    checked: usize,
+    succeeded: usize,
+    failed: usize,
+    skipped: usize,
+}
+
+struct SourceUpdateResult {
+    summary: SourceUpdateSummary,
+    error: Option<anyhow::Error>,
+}
+
 fn is_operational_source_failure(error: &anyhow::Error) -> bool {
     const OPERATIONAL_ERROR_PREFIXES: &[&str] = &[
         "[extension-admission]",
@@ -253,6 +266,7 @@ where
     async fn check_chapter_update(
         &self,
         mut rx: tokio::sync::mpsc::Receiver<Manga>,
+        run_kind: &str,
     ) -> Result<(), anyhow::Error> {
         let mut mangas_by_source: HashMap<i64, Vec<Manga>> = HashMap::new();
         while let Some(manga) = rx.recv().await {
@@ -269,15 +283,37 @@ where
             })
             .buffer_unordered(self.max_concurrent_sources);
         let mut first_error = None;
+        let mut source_summaries = Vec::new();
 
         while let Some((source_id, result)) = source_updates.next().await {
-            if let Err(error) = result {
+            source_summaries.push((source_id, result.summary));
+            if let Some(error) = result.error {
                 error!("update scan stopped for source {source_id}: {error}");
                 if first_error.is_none() {
                     first_error = Some(error);
                 }
             }
         }
+
+        source_summaries.sort_unstable_by_key(|(source_id, _)| *source_id);
+        let mut run_summary = SourceUpdateSummary::default();
+        for (source_id, summary) in source_summaries {
+            info!(
+                "UPDATE SOURCE SUMMARY: mode={run_kind} source_id={source_id} checked={} succeeded={} failed={} skipped={}",
+                summary.checked, summary.succeeded, summary.failed, summary.skipped
+            );
+            run_summary.checked += summary.checked;
+            run_summary.succeeded += summary.succeeded;
+            run_summary.failed += summary.failed;
+            run_summary.skipped += summary.skipped;
+        }
+        info!(
+            "UPDATE RUN SUMMARY: mode={run_kind} checked={} succeeded={} failed={} skipped={}",
+            run_summary.checked,
+            run_summary.succeeded,
+            run_summary.failed,
+            run_summary.skipped
+        );
 
         if let Some(error) = first_error {
             return Err(error);
@@ -290,19 +326,39 @@ where
         &self,
         source_id: i64,
         mangas: Vec<Manga>,
-    ) -> Result<(), anyhow::Error> {
+    ) -> SourceUpdateResult {
         let manga_count = mangas.len();
         let mut consecutive_failures = 0;
+        let mut summary = SourceUpdateSummary::default();
 
         for (index, manga) in mangas.into_iter().enumerate() {
-            match self.check_manga_update(manga).await? {
-                MangaUpdateOutcome::Success | MangaUpdateOutcome::ItemFailure => {
+            summary.checked += 1;
+            let outcome = match self.check_manga_update(manga).await {
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    summary.failed += 1;
+                    summary.skipped = manga_count.saturating_sub(index + 1);
+                    return SourceUpdateResult {
+                        summary,
+                        error: Some(error),
+                    };
+                }
+            };
+            match outcome {
+                MangaUpdateOutcome::Success => {
+                    summary.succeeded += 1;
+                    consecutive_failures = 0;
+                }
+                MangaUpdateOutcome::ItemFailure => {
+                    summary.failed += 1;
                     consecutive_failures = 0;
                 }
                 MangaUpdateOutcome::SourceFailure => {
+                    summary.failed += 1;
                     consecutive_failures += 1;
                     if consecutive_failures >= SOURCE_UPDATE_FAILURE_THRESHOLD {
                         let skipped = manga_count.saturating_sub(index + 1);
+                        summary.skipped = skipped;
                         error!(
                             "UPDATE SOURCE CIRCUIT OPEN: source_id={source_id} consecutive_operational_failures={consecutive_failures}; skipping {skipped} remaining manga for this run"
                         );
@@ -314,7 +370,10 @@ where
             tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         }
 
-        Ok(())
+        SourceUpdateResult {
+            summary,
+            error: None,
+        }
     }
 
     async fn check_manga_update(&self, manga: Manga) -> Result<MangaUpdateOutcome, anyhow::Error> {
@@ -530,21 +589,23 @@ where
                     match cmd {
                         ChapterUpdateCommand::All(tx) => {
                             self.start_chapter_update_queue_all(manga_tx);
-                            let res = self.check_chapter_update(manga_rx).await;
+                            let res = self.check_chapter_update(manga_rx, "manual-all").await;
                             if tx.send(res).is_err() {
                                 debug!("chapter update result receiver dropped (All)");
                             }
                         },
                         ChapterUpdateCommand::Manga(manga_id, tx) => {
                             self.start_chapter_update_queue_by_manga_id(manga_tx, manga_id).await;
-                            let res = self.check_chapter_update(manga_rx).await;
+                            let run_kind = format!("manual-manga:{manga_id}");
+                            let res = self.check_chapter_update(manga_rx, &run_kind).await;
                             if tx.send(res).is_err() {
                                 debug!("chapter update result receiver dropped (Manga {manga_id})");
                             }
                         },
                         ChapterUpdateCommand::Library(user_id, tx) => {
                             self.start_chapter_update_queue_by_user_id(manga_tx, user_id);
-                            let res = self.check_chapter_update(manga_rx).await;
+                            let run_kind = format!("manual-library:{user_id}");
+                            let res = self.check_chapter_update(manga_rx, &run_kind).await;
                             if tx.send(res).is_err() {
                                 debug!("chapter update result receiver dropped (Library user {user_id})");
                             }
@@ -561,7 +622,8 @@ where
                     let (manga_tx, manga_rx) = tokio::sync::mpsc::channel(1);
                     self.start_chapter_update_queue_all(manga_tx);
                     
-                    let check_chapter_result = self.check_chapter_update(manga_rx).await;
+                    let check_chapter_result =
+                        self.check_chapter_update(manga_rx, "periodic").await;
                     if let Err(e) = check_chapter_result {
                         error!("failed check chapter update: {e}");
                     }

--- a/crates/tanoshi/src/application/worker/updates.rs
+++ b/crates/tanoshi/src/application/worker/updates.rs
@@ -318,13 +318,6 @@ where
             return Err(error);
         }
 
-        if run_summary.failed > 0 || run_summary.skipped > 0 {
-            return Err(anyhow::anyhow!(
-                "update run {run_kind} completed with {} failed and {} skipped manga",
-                run_summary.failed, run_summary.skipped
-            ));
-        }
-
         Ok(())
     }
 

--- a/crates/tanoshi/src/application/worker/updates.rs
+++ b/crates/tanoshi/src/application/worker/updates.rs
@@ -379,14 +379,21 @@ where
 
         for chapter in chapters {
             for user in &users {
-                self.notifier
+                if let Err(error) = self
+                    .notifier
                     .send_chapter_notification(
                         user.id,
                         &manga.title,
                         &chapter.title,
                         chapter.id,
                     )
-                    .await?;
+                    .await
+                {
+                    error!(
+                        "failed to notify user {} about chapter '{}' of '{}': {error}",
+                        user.id, chapter.title, manga.title
+                    );
+                }
             }
 
             if let Err(e) = self.broadcast_tx.send(ChapterUpdate {

--- a/crates/tanoshi/src/application/worker/updates.rs
+++ b/crates/tanoshi/src/application/worker/updates.rs
@@ -28,6 +28,49 @@ use tokio::{
     time::{self, Instant},
 };
 
+const SOURCE_UPDATE_FAILURE_THRESHOLD: usize = 3;
+
+#[derive(Clone, Copy)]
+enum MangaUpdateOutcome {
+    Success,
+    ItemFailure,
+    SourceFailure,
+}
+
+fn is_operational_source_failure(error: &anyhow::Error) -> bool {
+    const OPERATIONAL_ERROR_PREFIXES: &[&str] = &[
+        "[extension-admission]",
+        "[extension-circuit-open]",
+        "[extension-panicked]",
+        "[extension-quarantined]",
+        "[extension-saturated]",
+        "[extension-timeout]",
+        "[extension-worker-busy]",
+        "[extension-worker-crashed]",
+        "[extension-worker-protocol]",
+        "[extension-worker-supervisor]",
+        "[extension-worker-timeout]",
+    ];
+
+    let message = error.to_string();
+    OPERATIONAL_ERROR_PREFIXES
+        .iter()
+        .any(|prefix| message.starts_with(prefix))
+        || error
+            .chain()
+            .any(|cause| cause.to_string() == "no such source")
+        || error.chain().any(|cause| {
+            cause
+                .downcast_ref::<reqwest::Error>()
+                .is_some_and(|error| {
+                    error.is_connect()
+                        || error.is_request()
+                        || error.is_status()
+                        || error.is_timeout()
+                })
+        })
+}
+
 #[derive(Debug, Clone)]
 pub struct ChapterUpdate {
     pub manga: Manga,
@@ -213,7 +256,7 @@ where
 
         let mut source_updates = futures::stream::iter(mangas_by_source)
             .map(|(source_id, mangas)| async move {
-                let result = self.check_source_updates(mangas).await;
+                let result = self.check_source_updates(source_id, mangas).await;
                 (source_id, result)
             })
             .buffer_unordered(self.max_concurrent_sources);
@@ -235,16 +278,38 @@ where
         Ok(())
     }
 
-    async fn check_source_updates(&self, mangas: Vec<Manga>) -> Result<(), anyhow::Error> {
-        for manga in mangas {
-            self.check_manga_update(manga).await?;
+    async fn check_source_updates(
+        &self,
+        source_id: i64,
+        mangas: Vec<Manga>,
+    ) -> Result<(), anyhow::Error> {
+        let manga_count = mangas.len();
+        let mut consecutive_failures = 0;
+
+        for (index, manga) in mangas.into_iter().enumerate() {
+            match self.check_manga_update(manga).await? {
+                MangaUpdateOutcome::Success | MangaUpdateOutcome::ItemFailure => {
+                    consecutive_failures = 0;
+                }
+                MangaUpdateOutcome::SourceFailure => {
+                    consecutive_failures += 1;
+                    if consecutive_failures >= SOURCE_UPDATE_FAILURE_THRESHOLD {
+                        let skipped = manga_count.saturating_sub(index + 1);
+                        error!(
+                            "UPDATE SOURCE CIRCUIT OPEN: source_id={source_id} consecutive_operational_failures={consecutive_failures}; skipping {skipped} remaining manga for this run"
+                        );
+                        break;
+                    }
+                }
+            }
+
             tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         }
 
         Ok(())
     }
 
-    async fn check_manga_update(&self, manga: Manga) -> Result<(), anyhow::Error> {
+    async fn check_manga_update(&self, manga: Manga) -> Result<MangaUpdateOutcome, anyhow::Error> {
         debug!("Checking updates: {}", manga.title);
 
         let chapters: Vec<Chapter> = match self
@@ -262,7 +327,11 @@ where
                 .collect(),
             Err(e) => {
                 error!("error fetch new chapters for {}, source {}, reason: {e}", manga.title, manga.source_id);
-                return Ok(());
+                return Ok(if is_operational_source_failure(&e) {
+                    MangaUpdateOutcome::SourceFailure
+                } else {
+                    MangaUpdateOutcome::ItemFailure
+                });
             }
         };
 
@@ -333,7 +402,7 @@ where
             }
         }
 
-        Ok(())
+        Ok(MangaUpdateOutcome::Success)
     }
 
     async fn check_extension_update(&self) -> Result<(), anyhow::Error> {

--- a/crates/tanoshi/src/infrastructure/config.rs
+++ b/crates/tanoshi/src/infrastructure/config.rs
@@ -91,6 +91,8 @@ pub struct Config {
     pub secret: String,
     #[serde(default = "default_update_interval")]
     pub update_interval: u64,
+    #[serde(default = "default_max_concurrent_update_sources")]
+    pub max_concurrent_update_sources: usize,
     #[serde(default)]
     pub auto_download_chapters: bool,
     #[serde(default = "default_plugin_path")]
@@ -123,6 +125,7 @@ impl Default for Config {
             create_database: default_create_database(),
             secret: default_secret(),
             update_interval: default_update_interval(),
+            max_concurrent_update_sources: default_max_concurrent_update_sources(),
             auto_download_chapters: false,
             plugin_path: default_plugin_path(),
             extension: ExtensionConfig::default(),
@@ -172,6 +175,10 @@ fn default_extension_repository() -> String {
 
 fn default_update_interval() -> u64 {
     3600
+}
+
+fn default_max_concurrent_update_sources() -> usize {
+    2
 }
 
 fn default_extension_max_concurrent_calls() -> usize {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable concurrency for manga update sources, with a default of two simultaneous sources.
  * Update processing now groups and handles sources independently for clearer progress and failure reporting.
  * Manual update requests now report queueing and processing errors more accurately.

* **Bug Fixes**
  * Prevented repeated operational failures from continuing to affect the same source during an update run.
  * Update runs now clearly indicate when items fail or are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->